### PR TITLE
fix: use cloudpickle for factory serialisation

### DIFF
--- a/sakura/lightning/__init__.py
+++ b/sakura/lightning/__init__.py
@@ -35,7 +35,7 @@ without a second worker.
 from __future__ import annotations
 
 import os
-import pickle
+import cloudpickle
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable, Optional
@@ -67,7 +67,7 @@ def _remote_validate(
     intentionally plain PyTorch — no Lightning process on the worker side —
     to keep the remote footprint small.
     """
-    import pickle as _pickle
+    import cloudpickle as _pickle
 
     import torch as _torch
     import torch.nn.functional as F
@@ -122,8 +122,8 @@ class SakuraLightningCallback(Callback):
     ) -> None:
         super().__init__()
         self._compute = compute
-        self._model_factory_bytes = pickle.dumps(model_factory)
-        self._val_loader_factory_bytes = pickle.dumps(val_loader_factory)
+        self._model_factory_bytes = cloudpickle.dumps(model_factory)
+        self._val_loader_factory_bytes = cloudpickle.dumps(val_loader_factory)
         self._model_path = model_path
         self._verbose = verbose
 
@@ -143,7 +143,7 @@ class SakuraLightningCallback(Callback):
         # user sees losses in order and so we don't stack pending futures.
         self._drain(trainer)
 
-        state_bytes = pickle.dumps(
+        state_bytes = cloudpickle.dumps(
             {k: v.detach().cpu() for k, v in pl_module.state_dict().items()}
         )
         epoch = trainer.current_epoch

--- a/sakura/ml/async_trainer.py
+++ b/sakura/ml/async_trainer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-import pickle
+import cloudpickle
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable, Optional
@@ -26,7 +26,7 @@ def _remote_test(
 
     Returning a plain dict keeps the protocol framework-agnostic.
     """
-    import pickle as _pickle
+    import cloudpickle as _pickle
 
     state_dict = _pickle.loads(state_bytes)
     model_factory = _pickle.loads(model_factory_bytes)
@@ -71,8 +71,8 @@ class AsyncTrainer:
     ) -> None:
         self._trainer = trainer
         self._compute = val_compute if val_compute is not None else zk.Compute()
-        self._model_factory_bytes = pickle.dumps(model_factory)
-        self._test_fn_bytes = pickle.dumps(test_fn)
+        self._model_factory_bytes = cloudpickle.dumps(model_factory)
+        self._test_fn_bytes = cloudpickle.dumps(test_fn)
         self._pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="sakura-test")
         self._pending: Optional[Future] = None
 
@@ -97,7 +97,7 @@ class AsyncTrainer:
                 # Some Trainer implementations return already-pickled bytes;
                 # others return a dict. Accept either and normalize to bytes.
                 if not isinstance(state_bytes, (bytes, bytearray)):
-                    state_bytes = pickle.dumps(state_bytes)
+                    state_bytes = cloudpickle.dumps(state_bytes)
                 self._pending = self._pool.submit(
                     self._dispatch,
                     bytes(state_bytes),


### PR DESCRIPTION
## Summary

Follow-up to #33. `pickle.dumps` cannot serialise local lambdas, so the obvious usage pattern from the PR description:

```python
SakuraTrainer(val_loader_factory=lambda: val_loader, ...)
```

crashed with `AttributeError: Can't pickle local object`. Swap `pickle` for `cloudpickle` (already a transitive dep via zakuro-ai) in both `sakura.lightning` and `sakura.ml.async_trainer` so factories, closures, and classes defined in `__main__` all round-trip cleanly.

## Verified

End-to-end MNIST run on a laptop with no worker (zakuro standalone fallback):

\`\`\`
uv run python main.py --mode sakura --epochs 2 --batch-size 256
  ...
  [Sakura] epoch=0 val_loss=0.0939 on=<standalone> took=4.73s
  [Sakura] epoch=1 val_loss=0.0659 on=<standalone> took=4.31s
  Sakura:   12.26s
\`\`\`

Training of epoch N+1 overlapped validation of epoch N, as expected. 20/20 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)