### PR TITLE
docs: interactive async-training benchmark notebook

### DIFF
--- a/bert_demo/bench_notebook.ipynb
+++ b/bert_demo/bench_notebook.ipynb
@@ -1,0 +1,411 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sakura \u2192 Zakuro async-training benchmark\n",
+    "\n",
+    "Walks through the three stages of Sakura's async-eval pipeline on a BERT fine-tune:\n",
+    "\n",
+    "1. **Serial baseline** \u2014 the `transformers.Trainer` default: one epoch trains, then the same process runs the full eval loop before the next epoch starts.\n",
+    "2. **Sakura na\u00efve async** \u2014 eval goes to a Zakuro worker via `@zk.fn`; training no longer blocks, but the callback still has to cloudpickle a full state-dict each epoch.\n",
+    "3. **Sakura + `zk.AdaptiveCompute`** \u2014 the Adam-style allocator tracks per-worker latency EMA, exposes a backpressure signal, and lets the callback *skip* an epoch's eval when the slow side can't keep up. Training stays unblocked.\n",
+    "\n",
+    "The notebook uses Zakuro's standalone fallback (in-process execution) by default so it runs on a laptop with no worker setup. Set `WORKER_URI` to point at a real QUIC worker for cross-machine runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "\n",
+    "os.environ.setdefault(\"TRANSFORMERS_VERBOSITY\", \"error\")\n",
+    "os.environ.setdefault(\"TOKENIZERS_PARALLELISM\", \"false\")\n",
+    "\n",
+    "import torch\n",
+    "from datasets import load_dataset\n",
+    "from transformers import (\n",
+    "    AutoConfig,\n",
+    "    AutoModelForSequenceClassification,\n",
+    "    AutoTokenizer,\n",
+    "    Trainer,\n",
+    "    TrainingArguments,\n",
+    ")\n",
+    "\n",
+    "import zakuro as zk\n",
+    "from sakura.huggingface import SakuraHFCallback\n",
+    "\n",
+    "print(\"torch:\", torch.__version__)\n",
+    "print(\"zakuro:\", zk.__version__)\n",
+    "print(\"has AdaptiveCompute:\", hasattr(zk, \"AdaptiveCompute\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Knobs you can tweak. The defaults are intentionally small so the notebook runs in a couple of minutes end-to-end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = \"distilbert-base-uncased\"\n",
+    "TRAIN_SIZE = 600\n",
+    "VAL_SIZE = 1200\n",
+    "MAX_LENGTH = 64\n",
+    "EPOCHS = 4\n",
+    "BATCH_SIZE = 32\n",
+    "\n",
+    "# Leave None to use Zakuro's standalone fallback. Set to e.g.\n",
+    "# \"quic://192.168.0.220:4445\" to target a real worker.\n",
+    "WORKER_URI = os.environ.get(\"SAKURA_VAL_WORKER\", None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "raw = load_dataset(\"glue\", \"sst2\")\n",
+    "\n",
+    "def tokenize(batch):\n",
+    "    return tokenizer(\n",
+    "        batch[\"sentence\"], padding=\"max_length\", truncation=True, max_length=MAX_LENGTH\n",
+    "    )\n",
+    "\n",
+    "train = raw[\"train\"].shuffle(seed=42).select(range(TRAIN_SIZE)).map(tokenize, batched=True)\n",
+    "val = raw[\"validation\"].shuffle(seed=42).select(range(min(VAL_SIZE, len(raw[\"validation\"])))).map(\n",
+    "    tokenize, batched=True\n",
+    ")\n",
+    "cols = [\"input_ids\", \"attention_mask\", \"label\"]\n",
+    "train.set_format(\"torch\", columns=cols)\n",
+    "val.set_format(\"torch\", columns=cols)\n",
+    "print(f\"train: {len(train)}  val: {len(val)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Helpers\n",
+    "\n",
+    "A single `model_factory` + `eval_fn` pair used by both async modes. Imports live inside `eval_fn` so it cloudpickles cleanly for cross-Python-version workers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_config = AutoConfig.from_pretrained(MODEL_NAME, num_labels=2)\n",
+    "\n",
+    "def model_factory():\n",
+    "    # Architecture only \u2014 Sakura streams the weights over each epoch.\n",
+    "    return AutoModelForSequenceClassification.from_config(_config)\n",
+    "\n",
+    "def eval_fn(model, payload):\n",
+    "    import torch as _torch\n",
+    "\n",
+    "    data, bs = payload\n",
+    "    if _torch.cuda.is_available():\n",
+    "        device = _torch.device(\"cuda\")\n",
+    "    elif getattr(_torch.backends, \"mps\", None) and _torch.backends.mps.is_available():\n",
+    "        device = _torch.device(\"mps\")\n",
+    "    else:\n",
+    "        device = _torch.device(\"cpu\")\n",
+    "    model.to(device)\n",
+    "\n",
+    "    loss_sum = 0.0\n",
+    "    correct = 0\n",
+    "    total = 0\n",
+    "    with _torch.no_grad():\n",
+    "        for start in range(0, len(data[\"input_ids\"]), bs):\n",
+    "            batch = {k: data[k][start:start+bs].to(device) for k in (\"input_ids\", \"attention_mask\")}\n",
+    "            labels = data[\"label\"][start:start+bs].to(device)\n",
+    "            out = model(**batch, labels=labels)\n",
+    "            loss_sum += float(out.loss.item()) * labels.size(0)\n",
+    "            correct += int((out.logits.argmax(-1) == labels).sum().item())\n",
+    "            total += int(labels.size(0))\n",
+    "    return {\"val_loss\": loss_sum / max(total, 1), \"val_acc\": correct / max(total, 1)}\n",
+    "\n",
+    "# Materialise the val tensors so they pickle cleanly (no Arrow backing).\n",
+    "val_payload = (\n",
+    "    {\n",
+    "        \"input_ids\": torch.stack([val[i][\"input_ids\"] for i in range(len(val))]).clone(),\n",
+    "        \"attention_mask\": torch.stack([val[i][\"attention_mask\"] for i in range(len(val))]).clone(),\n",
+    "        \"label\": torch.stack([val[i][\"label\"] for i in range(len(val))]).clone(),\n",
+    "    },\n",
+    "    BATCH_SIZE,\n",
+    ")\n",
+    "print(\"helpers ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _args(outdir, eval_strategy):\n",
+    "    return TrainingArguments(\n",
+    "        output_dir=outdir,\n",
+    "        num_train_epochs=EPOCHS,\n",
+    "        per_device_train_batch_size=BATCH_SIZE,\n",
+    "        per_device_eval_batch_size=BATCH_SIZE,\n",
+    "        eval_strategy=eval_strategy,\n",
+    "        save_strategy=\"no\",\n",
+    "        logging_strategy=\"no\",\n",
+    "        report_to=[],\n",
+    "        disable_tqdm=True,\n",
+    "        seed=42,\n",
+    "        dataloader_num_workers=0,\n",
+    "        fp16=torch.cuda.is_available(),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Serial baseline\n",
+    "\n",
+    "`transformers.Trainer` with `eval_strategy=\"epoch\"`. Evaluation happens inline \u2014 training waits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    args=_args(\"/tmp/sakura-nb/serial\", \"epoch\"),\n",
+    "    train_dataset=train,\n",
+    "    eval_dataset=val,\n",
+    ")\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "trainer.train()\n",
+    "serial_wall = time.perf_counter() - t0\n",
+    "serial_final_loss = trainer.evaluate()[\"eval_loss\"]\n",
+    "print(f\"serial: {serial_wall:.2f}s  final val_loss={serial_final_loss:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Sakura na\u00efve async\n",
+    "\n",
+    "`SakuraHFCallback` attached; `eval_strategy=\"no\"` so `Trainer` doesn't try to eval. The callback ships each epoch's state-dict to a Zakuro worker (or standalone fallback).\n",
+    "\n",
+    "No backpressure yet \u2014 the callback dispatches unconditionally. Training runs at the mercy of whichever side is slower."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if WORKER_URI:\n",
+    "    compute = zk.Compute(uri=WORKER_URI, verify=False)\n",
+    "    print(f\"async eval \u2192 {compute.uri}\")\n",
+    "else:\n",
+    "    compute = zk.Compute()  # standalone fallback\n",
+    "    print(\"async eval \u2192 zakuro standalone (in-process)\")\n",
+    "\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)\n",
+    "cb_naive = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=compute,\n",
+    "    drain=\"lazy\",\n",
+    "    cache_key=f\"nb-{MODEL_NAME}\",\n",
+    "    fp16_state_dict=True,\n",
+    "    on_backpressure=\"queue\",    # always dispatch, even under load\n",
+    "    verbose=False,\n",
+    ")\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    args=_args(\"/tmp/sakura-nb/naive\", \"no\"),\n",
+    "    train_dataset=train,\n",
+    "    callbacks=[cb_naive],\n",
+    ")\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "trainer.train()\n",
+    "naive_wall = time.perf_counter() - t0\n",
+    "print(f\"na\u00efve async: {naive_wall:.2f}s\")\n",
+    "for row in cb_naive.history:\n",
+    "    if row.get(\"skipped\"):\n",
+    "        print(f\"  epoch {int(row['epoch'])}: SKIPPED\")\n",
+    "    else:\n",
+    "        print(f\"  epoch {int(row['epoch'])}: loss={row['val_loss']:.4f} acc={row['val_acc']:.4f} took={row['elapsed_secs']:.2f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Sakura + `zk.AdaptiveCompute`\n",
+    "\n",
+    "Same setup, but `val_compute` is wrapped in `AdaptiveCompute`. The allocator tracks per-worker latency EMA (Adam-style), exposes `is_backpressured()`, and the callback's `on_backpressure=\"skip\"` lets training continue when the slow side can't keep up.\n",
+    "\n",
+    "With a single worker, adaptive's main value is the backpressure signal. With multiple workers it also routes by expected time-to-serve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adaptive = zk.AdaptiveCompute(\n",
+    "    workers=[compute],\n",
+    "    beta1=0.7,         # responsive to recent observations\n",
+    "    beta2=0.99,\n",
+    "    backpressure_threshold=3.0,  # seconds\n",
+    "    initial_latency=0.5,\n",
+    ")\n",
+    "\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)\n",
+    "cb_adaptive = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=adaptive,\n",
+    "    drain=\"lazy\",\n",
+    "    cache_key=f\"nb-{MODEL_NAME}\",\n",
+    "    fp16_state_dict=True,\n",
+    "    on_backpressure=\"skip\",     # drop this epoch's eval when overloaded\n",
+    "    verbose=False,\n",
+    ")\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    args=_args(\"/tmp/sakura-nb/adaptive\", \"no\"),\n",
+    "    train_dataset=train,\n",
+    "    callbacks=[cb_adaptive],\n",
+    ")\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "trainer.train()\n",
+    "adaptive_wall = time.perf_counter() - t0\n",
+    "print(f\"adaptive: {adaptive_wall:.2f}s\")\n",
+    "evals = [r for r in cb_adaptive.history if not r.get(\"skipped\")]\n",
+    "skips = [r for r in cb_adaptive.history if r.get(\"skipped\")]\n",
+    "for row in evals:\n",
+    "    print(f\"  epoch {int(row['epoch'])}: loss={row['val_loss']:.4f} acc={row['val_acc']:.4f} took={row['elapsed_secs']:.2f}s\")\n",
+    "print(f\"  skipped by backpressure: {len(skips)} epoch(s)\")\n",
+    "print(\"\\nallocator stats:\")\n",
+    "for i, s in enumerate(adaptive.stats()):\n",
+    "    print(f\"  worker {i}: step={s['step']} queue={s['queue']} ema={s['latency_ema']:.3f}s var={s['latency_var']:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Comparison\n",
+    "\n",
+    "Wall-clock summary. Rows should show: serial competes well on the fast side; async na\u00efve can lose for small per-epoch eval times because the dispatch overhead exceeds savings; adaptive approaches serial from below by skipping evals the mesh can't absorb."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = [\n",
+    "    (\"serial\", serial_wall),\n",
+    "    (\"naive async\", naive_wall),\n",
+    "    (\"adaptive + skip\", adaptive_wall),\n",
+    "]\n",
+    "width = 20\n",
+    "print(f\"{'mode':<{width}}{'wall (s)':>10}{'\u0394 vs serial':>14}\")\n",
+    "print(\"-\" * (width + 24))\n",
+    "for name, wall in rows:\n",
+    "    delta = wall - serial_wall\n",
+    "    pct = 100 * delta / serial_wall\n",
+    "    arrow = \"\" if name == \"serial\" else f\"{'+' if delta > 0 else ''}{delta:.2f}s ({pct:+.1f}%)\"\n",
+    "    print(f\"{name:<{width}}{wall:>10.2f}{arrow:>14}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional: plot a simple bar chart if matplotlib is around.\n",
+    "try:\n",
+    "    import matplotlib.pyplot as plt\n",
+    "    names = [r[0] for r in rows]\n",
+    "    vals = [r[1] for r in rows]\n",
+    "    fig, ax = plt.subplots(figsize=(6, 3))\n",
+    "    ax.bar(names, vals, color=[\"#8bb174\", \"#d4a373\", \"#ae5577\"])\n",
+    "    ax.set_ylabel(\"wall-clock seconds\")\n",
+    "    ax.set_title(f\"{MODEL_NAME} \u2022 {EPOCHS} epochs \u2022 val size={VAL_SIZE}\")\n",
+    "    for name, v in zip(names, vals):\n",
+    "        ax.text(name, v, f\"{v:.1f}s\", ha=\"center\", va=\"bottom\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "except ImportError:\n",
+    "    print(\"matplotlib not installed; skipping plot.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- On a single machine (standalone fallback) the async path **can lose** to serial if eval is much cheaper than training: the cloudpickle + thread-pool overhead eats the potential savings. This is honest; the framework can't overcome that physics.\n",
+    "- Async **wins** when:\n",
+    "  - Training time per epoch is comparable to or greater than eval time.\n",
+    "  - Eval contains CPU-bound work (seqeval, BLEU, BERTScore) where Mac \u2248 x399.\n",
+    "  - Multiple eval workers are available and the allocator can fan out.\n",
+    "  - You care about metric sampling rate more than per-epoch granularity \u2014 adaptive's skip policy trades some metrics for faster wall-clock.\n",
+    "- See [`zakuro/PLAN.md`](https://github.com/zakuro-ai/zakuro/blob/master/PLAN.md) for the roadmap toward grid-aware scheduling and truly-decoupled checkpoint handling, which should push async well past serial on typical workloads."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds `bert_demo/bench_notebook.ipynb` — an interactive walk-through of the three async-training stages on a BERT fine-tune.

## Cells

1. **Setup + config** — imports, `MODEL_NAME`, `TRAIN_SIZE`, `VAL_SIZE`, etc.
2. **Data** — SST-2 loaded via `datasets`, tokenised once, shared by all three runs.
3. **Helpers** — `model_factory` (`from_config`, no redundant weight load), `eval_fn` (device-auto torch loop), materialised val payload.
4. **Serial baseline** — `transformers.Trainer` with `eval_strategy="epoch"`. Eval blocks training between epochs.
5. **Naïve async** — `SakuraHFCallback` with `on_backpressure="queue"` (always dispatch).
6. **Adaptive + backpressure** — same callback wrapped with `zk.AdaptiveCompute`, `on_backpressure="skip"`. Training stays unblocked when the slow side can't keep up.
7. **Comparison table** + optional matplotlib bar chart.
8. **Notes** — honest commentary on when async wins vs loses, pointing at `zakuro/PLAN.md` for the roadmap.

## Runs out of the box

- Default: Zakuro standalone fallback → runs on a laptop with no external workers in a couple of minutes.
- Set `SAKURA_VAL_WORKER=quic://host:4433` to point at a real QUIC worker for cross-machine runs.

## Test plan

- [x] Notebook JSON validates with `json.load`.
- [x] Cells are numbered sequentially, no stale IDs.
- [x] Works with the public API as of `perf/async-improvements-v2` (merged in #36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
