### PR TITLE
docs: rewrite README for the Zakuro-powered era

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,209 +1,182 @@
-<h1 align="center">
-  <br>
-  <img src="https://drive.google.com/uc?id=1Mz2WqXHrwEOjwtWfJVHV7NiRwC_64Shh">
-</h1>
+<h1 align="center">Sakura</h1>
+
 <p align="center">
-  <a href="#modules">Modules</a> •
-  <a href="#code-structure">Code structure</a> •
-  <a href="#code-design">Code design</a> •
-  <a href="#installing-the-application">Installing the application</a> •
-  <a href="#makefile-commands">Makefile commands</a> •
-  <a href="#environments">Environments</a> •
-  <a href="#running-the-application">Running the application</a>
+  ML-framework integrations for <a href="https://github.com/zakuro-ai/zakuro">Zakuro</a> —
+  hide evaluation, logging, and checkpointing behind training so the main loop never waits.
 </p>
 
+<p align="center">
+  <a href="#quick-start">Quick Start</a> •
+  <a href="#installation">Installation</a> •
+  <a href="#pytorch-lightning">Lightning</a> •
+  <a href="#huggingface-trainer">HuggingFace</a> •
+  <a href="#tensorflow--keras">TensorFlow</a> •
+  <a href="#benchmarks--notebooks">Benchmarks</a>
+</p>
 
 --------------------------------------------------------------------------------
 
-Sakura is a simple but powerfull tool to reduce training time by running the train/test asynchronously. It provides two features:
-- A simple ML framework for asynchronous training.
-- An integration with PyTorch. 
+## What is Sakura?
 
+Sakura wraps the framework you're already using (PyTorch Lightning, HuggingFace `Trainer`, TensorFlow `Model.fit`) with a callback that **dispatches evaluation to a [Zakuro](https://github.com/zakuro-ai/zakuro) worker** instead of running it inline. Training keeps stepping while eval runs on a side pool; metrics come back through a non-blocking queue.
 
-You can reuse your favorite Python framework such as Pytorch, Tensorflow or PaddlePaddle.
+The old Sakura used MPI + Redis for this plumbing. The current Sakura uses Zakuro — one `@zk.fn` dispatch per epoch, shared connection, context-aware allocation across a pool of workers. No MPI, no Redis, no `SAKURA_ROLE` fork.
 
+## Quick start
 
-# Modules
+### Laptop-only (no worker setup)
 
-At a granular level, Sakura is a library that consists of the following components:
-
-| Component | Description |
-| ---- | --- |
-| **sakura** | Contains the sakura modules. |
-| **sakura.ml** | Contains the code related to ml processing |
-
-
-
-# Code structure
 ```python
-from setuptools import setup
-from sakura import __version__
-
-setup(
-    name="sakura-ml",
-    version=__version__,
-    short_description="Sakura provides asynchronous training for DNN.",
-    long_description="Sakura provides asynchronous training for DNN.",
-    url='https://zakuro.ai',
-    packages=[
-        "sakura",
-        "sakura.lightning",
-    ],
-    include_package_data=True,
-    package_data={"": ["*.yml"]},
-    install_requires=[r.rsplit()[0] for r in open("requirements.txt")],
-    license='MIT',
-    author='ZakuroAI',
-    python_requires='>=3.6',
-    author_email='git@zakuro.ai',
-    description='Sakura provides asynchronous training for DNN.',
-    platforms="linux_debian_10_x86_64",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-    ]
-)
-```
-# Code design
-If you worked with PyTorch in your project your would find a common structure. 
-Simply change the `test` and `train` in your trainer as shown in `mnist_demo`. 
-```python
-import os
 import lightning as L
-import torch
-from torch import nn
-from torch.nn import functional as F
-from torch.utils.data import DataLoader
-from torchvision import transforms
-from torchvision.datasets import MNIST
-import argparse
 from sakura.lightning import SakuraTrainer
 
-
-class MNISTModel(L.LightningModule):
-    def __init__(self):
-        super(MNISTModel, self).__init__()
-        self.conv1 = nn.Conv2d(1, 32, 3, 1)
-        self.conv2 = nn.Conv2d(32, 64, 3, 1)
-        self.dropout1 = nn.Dropout(0.25)
-        self.dropout2 = nn.Dropout(0.5)
-        self.fc1 = nn.Linear(9216, 128)
-        self.fc2 = nn.Linear(128, 10)
-
-    def forward(self, x):
-        x = self.conv1(x)
-        x = F.relu(x)
-        x = self.conv2(x)
-        x = F.relu(x)
-        x = F.max_pool2d(x, 2)
-        x = self.dropout1(x)
-        x = torch.flatten(x, 1)
-        x = self.fc1(x)
-        x = F.relu(x)
-        x = self.dropout2(x)
-        x = self.fc2(x)
-        output = F.log_softmax(x, dim=1)
-        return output
-
-    def training_step(self, batch, batch_nb):
-        x, y = batch
-        loss = F.cross_entropy(self(x), y)
-        return loss
-
-    def validation_step(self, batch, batch_nb):
-        with torch.no_grad():
-            x, y = batch
-            loss = F.cross_entropy(self(x), y)
-        return loss
-
-    def configure_optimizers(self):
-        return torch.optim.Adam(self.parameters(), lr=0.02)
-
-
-if __name__ == "__main__":
-    PATH_DATASETS = os.environ.get("PATH_DATASETS", ".")
-    BATCH_SIZE = 2000 if torch.cuda.is_available() else 64
-    # Init our model
-    mnist_model = MNISTModel()
-
-    # Init DataLoader from MNIST Dataset
-    train_ds = MNIST(
-        PATH_DATASETS, train=True, download=True, transform=transforms.ToTensor()
-    )
-    train_loader = DataLoader(train_ds, batch_size=BATCH_SIZE)
-
-    # Init DataLoader from MNIST Dataset
-    val_ds = MNIST(
-        PATH_DATASETS, train=False, download=True, transform=transforms.ToTensor()
-    )
-    val_loader = DataLoader(val_ds, batch_size=BATCH_SIZE)
-
-    trainer = SakuraTrainer(
-        accelerator="auto",
-        max_epochs=10,
-    )
-
-    trainer.run(
-        mnist_model, train_loader, val_loader, model_path="models/best_model.pth"
-    )
-
+trainer = SakuraTrainer(
+    max_epochs=10,
+    accelerator="auto",
+    model_factory=MyLightningModule,     # rebuilds on the eval worker
+    val_loader_factory=lambda: val_loader,
+)
+trainer.run(model, train_loader)          # val_compute=None → Zakuro standalone fallback
 ```
 
-# Installing the application
-To clone and run this application, you'll need the following installed on your computer:
-- [Git](https://git-scm.com)
-- Docker Desktop
-   - [Install Docker Desktop on Mac](https://docs.docker.com/docker-for-mac/install/)
-   - [Install Docker Desktop on Windows](https://docs.docker.com/desktop/install/windows-install/)
-   - [Install Docker Desktop on Linux](https://docs.docker.com/desktop/install/linux-install/)
-- [Python](https://www.python.org/downloads/)
+No `zakuro-worker` needed — the eval runs in-process via Zakuro's standalone fallback, but the async dispatch pattern still works.
 
-### Clone the code and install the binary
-```bash
-# Clone this repository and install the code
-git clone https://github.com/zakuro-ai/sakura
+### HuggingFace `Trainer` with a real worker
 
-# Go into the repository
-cd sakura
+```python
+from transformers import Trainer, TrainingArguments
+from sakura.huggingface import SakuraHFCallback
+import zakuro as zk
 
-# Update global variables
-source .env
-
-# Install sakura
-curl https://get.zakuro.ai/sakura/install | sh
+trainer = Trainer(
+    model=model,
+    args=TrainingArguments(..., eval_strategy="no"),   # we handle eval
+    train_dataset=train_ds,
+    callbacks=[
+        SakuraHFCallback(
+            model_factory=lambda: AutoModelForSequenceClassification.from_config(config),
+            eval_fn=my_eval_fn,
+            eval_payload=(val_inputs, 32),
+            val_compute=zk.Compute(uri="quic://worker:4433"),
+            fp16_state_dict=True,
+            on_backpressure="skip",
+        )
+    ],
+)
+trainer.train()
 ```
 
-### Check that the binary has been downloaded
-```bash
-which sakura
-```
+`on_backpressure="skip"` makes the callback consult `AdaptiveCompute.is_backpressured()` before every dispatch — if the allocator reports saturation (the slow eval worker can't keep up), that epoch's eval is dropped rather than blocking training.
 
-# Running the application
+## Installation
 
 ```bash
-sakura main.py
-```
-You should be able to see this output with no delay between epochs (asynchronous testing).
-```
-   _____           _                               __  __   _      
-  / ____|         | |                             |  \/  | | |     
- | (___     __ _  | | __  _   _   _ __    __ _    | \  / | | |     
-  \___ \   / _` | | |/ / | | | | | '__|  / _` |   | |\/| | | |     
-  ____) | | (_| | |   <  | |_| | | |    | (_| |   | |  | | | |____ 
- |_____/   \__,_| |_|\_\  \__,_| |_|     \__,_|   |_|  |_| |______|
+# Core + HuggingFace integration
+pip install 'sakura-ml[huggingface]'
 
-(0) MNIST | Epoch: 1/10 | Acc: 0.0000 / (0.0000) | Loss:0.0000 / (0.0000): 100%|██████████| 18/18 [00:06<00:00,  2.69it/s]
-(1) MNIST | Epoch: 2/10 | Acc: 0.0000 / (0.0000) | Loss:0.0000 / (0.0000): 100%|██████████| 18/18 [00:05<00:00,  3.36it/s]
-(2) MNIST | Epoch: 3/10 | Acc: 90.4600 / (90.4600) | Loss:0.4034 / (0.4034): 100%|██████████| 18/18 [00:05<00:00,  3.42it/s]
-(3) MNIST | Epoch: 4/10 | Acc: 95.3246 / (95.3246) | Loss:0.1907 / (0.1907): 100%|██████████| 18/18 [00:05<00:00,  3.43it/s]
-(4) MNIST | Epoch: 5/10 | Acc: 96.9332 / (96.9332) | Loss:0.1379 / (0.1379): 100%|██████████| 18/18 [00:05<00:00,  3.38it/s]
-(5) MNIST | Epoch: 6/10 | Acc: 97.3693 / (97.3693) | Loss:0.1167 / (0.1167): 100%|██████████| 18/18 [00:05<00:00,  3.42it/s]
-(6) MNIST | Epoch: 7/10 | Acc: 97.7237 / (97.7237) | Loss:0.1040 / (0.1040): 100%|██████████| 18/18 [00:05<00:00,  3.41it/s]
-(7) MNIST | Epoch: 8/10 | Acc: 98.0172 / (98.0172) | Loss:0.0938 / (0.0938): 100%|██████████| 18/18 [00:05<00:00,  3.31it/s]
-(8) MNIST | Epoch: 9/10 | Acc: 98.2402 / (98.2402) | Loss:0.0886 / (0.0886): 100%|██████████| 18/18 [00:05<00:00,  3.41it/s]
+# Everything
+pip install 'sakura-ml[huggingface,tensorflow,bench]'
+
+# From source
+git clone https://github.com/zakuro-ai/sakura && cd sakura
+uv pip install -e '.[huggingface]'
 ```
 
-FYI the meaning of the above notation is:
+Zakuro is pulled transitively. For a worker (HTTP or QUIC) install the `[worker]` extra on the zakuro package.
+
+## PyTorch Lightning
+
+`sakura.lightning.SakuraTrainer` — a drop-in replacement for the async-eval case:
+
+```python
+from sakura.lightning import SakuraTrainer
+
+trainer = SakuraTrainer(
+    max_epochs=10,
+    accelerator="auto",
+    # how the eval worker rebuilds the model:
+    model_factory=lambda: MyLightningModule(),
+    # how the eval worker rebuilds the dataloader:
+    val_loader_factory=lambda: DataLoader(val_ds, batch_size=256),
+    # optional: where to run eval
+    val_compute=zk.Compute(uri="quic://eval-worker:4433"),
+    # optional: where to save the best-loss checkpoint
+    model_path="checkpoints/best.pth",
+)
+trainer.run(model, train_loader)
+
+print(trainer.history)         # [{epoch, val_loss, worker_name, elapsed_secs}, ...]
+print(trainer.best_val_loss)
 ```
-([best_epoch]) [name_exp] | Epoch: [current]/[total] | Acc: [current_test_acc] / ([best_test_acc]) | Loss:[current_test_loss] / ([best_test_loss]): 100%|███| [batch_k]/[batch_n] [[time_train]<[time_left], [it/s]]
+
+## HuggingFace Trainer
+
+`sakura.huggingface.SakuraHFCallback` is a `transformers.TrainerCallback` that cloudpickles `state_dict` on `on_epoch_end`, dispatches a remote eval, and lazily reaps futures as they finish. Knobs:
+
+| parameter | what it does |
+|---|---|
+| `model_factory` | how the eval worker rebuilds the architecture (weights stream in from the callback) |
+| `eval_fn(model, payload)` | the eval routine itself — runs on the worker, returns a `dict` of metrics |
+| `eval_payload` | anything cloudpickle can serialise — dataset, tokenizer, batch size |
+| `val_compute` | `zk.Compute` or `zk.AdaptiveCompute`; `None` → standalone |
+| `drain="lazy"` *(default)* / `"strict"` | whether `on_epoch_end` blocks to reap the previous future |
+| `cache_key=...` | keep the validator model architecture warm on the worker |
+| `fp16_state_dict=True` | halve the wire bytes |
+| `async_copy=True` *(default, CUDA-only)* | GPU→CPU snapshot on a dedicated stream, ~170 → 75 ms per epoch on x399 4090 |
+| `on_backpressure={"skip","queue","block"}` | policy when `AdaptiveCompute` reports saturation |
+| `max_pending` | cap on in-flight evaluations |
+
+In-memory fast path is **automatic**: when `val_compute` resolves to standalone, `torch.save`/`torch.load` are skipped entirely — measured +23.6 % wall on a 3-epoch distilbert fine-tune vs forced serialisation.
+
+## TensorFlow / Keras
+
+`sakura.tensorflow.SakuraKerasCallback` — a `tf.keras.callbacks.Callback` with the same pattern:
+
+```python
+from sakura.tensorflow import SakuraKerasCallback
+
+model.fit(
+    x_train, y_train,
+    epochs=10,
+    callbacks=[SakuraKerasCallback(
+        model_factory=lambda: tf.keras.Sequential([...]),
+        val_fn=lambda m, p: m.evaluate(*p, verbose=0, return_dict=True),
+        val_payload=(x_val, y_val),
+        val_compute=zk.Compute(uri="quic://eval-worker:4433"),
+    )],
+)
 ```
+
+Weights are transferred as numpy arrays via `get_weights()` / `set_weights()` — clean cloudpickle, no TF graph-state serialisation.
+
+## Generic async trainer (framework-agnostic)
+
+`sakura.ml.async_trainer.AsyncTrainer` — for training loops that aren't Lightning / HF / Keras. Takes any object implementing `train(loader)`, `serialized_state_dict()`, `_epochs`, `_metrics`, plus a `model_factory` and `test_fn(model) -> dict`. Same dispatch mechanics.
+
+## Benchmarks & notebooks
+
+- **[`bert_demo/hf_async_features.ipynb`](bert_demo/hf_async_features.ipynb)** — every `SakuraHFCallback` knob exercised on distilbert / SST-2. Runs in ~1 min on a laptop. Verified via `jupyter nbconvert --execute`.
+- **[`bert_demo/bench_bert.py`](bert_demo/bench_bert.py)** — serial `Trainer` vs Sakura async, configurable.
+- **[`bert_demo/bench_in_memory_handle.py`](bert_demo/bench_in_memory_handle.py)** — A/B the in-memory-handle fast path against `torch.save`. +23.6 % end-to-end measured.
+
+## Measured performance wins (distilbert-base-uncased, 268 MB state_dict)
+
+| slice | before | after | measured on |
+|---|---|---|---|
+| blocking `.cpu()` → async CUDA-stream copy | 176 ms / epoch main-thread | **75 ms** / epoch | x399 4090 |
+| cloudpickle → `torch.save` for state_dict | 482 ms / epoch pool | **282 ms** / epoch | x399 CPU |
+| in-memory handle for standalone | 9.12 s wall (3 epochs) | **7.59 s** | Mac MPS |
+
+See [`zakuro/PLAN.md`](https://github.com/zakuro-ai/zakuro/blob/master/PLAN.md#measured-results-so-far) for the consolidated numbers across both repos.
+
+## Development
+
+```bash
+git clone https://github.com/zakuro-ai/sakura && cd sakura
+uv pip install -e '.[bench]'
+uv run pytest tests/
+```
+
+## License
+
+BSD-3-Clause.

--- a/bert_demo/hf_async_features.ipynb
+++ b/bert_demo/hf_async_features.ipynb
@@ -1,0 +1,410 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sakura — HF async-training feature tour\n",
+    "\n",
+    "Every knob `SakuraHFCallback` exposes, demonstrated on a tiny BERT fine-tune (SST-2 subset) so the notebook runs in about a minute on a CPU/MPS laptop.\n",
+    "\n",
+    "| knob | what it does |\n",
+    "|---|---|\n",
+    "| `drain=\"lazy\"` / `\"strict\"` | whether `on_epoch_end` blocks to reap the previous future |\n",
+    "| `cache_key=...` | keep the validator model architecture warm on the worker |\n",
+    "| `fp16_state_dict=True` | halve network bytes |\n",
+    "| `on_backpressure=\"skip\"/\"queue\"/\"block\"` | behaviour when `AdaptiveCompute` reports saturation |\n",
+    "| `async_copy=True` (CUDA-only) | GPU→CPU snapshot on a dedicated `torch.cuda.Stream` |\n",
+    "| in-memory handle | automatic shortcut when the compute is standalone — skip `torch.save` entirely |\n",
+    "\n",
+    "Reference `zakuro/PLAN.md` for the full measured numbers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "\n",
+    "os.environ.setdefault(\"TRANSFORMERS_VERBOSITY\", \"error\")\n",
+    "os.environ.setdefault(\"TOKENIZERS_PARALLELISM\", \"false\")\n",
+    "\n",
+    "import torch\n",
+    "from datasets import load_dataset\n",
+    "from transformers import (\n",
+    "    AutoConfig,\n",
+    "    AutoModelForSequenceClassification,\n",
+    "    AutoTokenizer,\n",
+    "    Trainer,\n",
+    "    TrainingArguments,\n",
+    ")\n",
+    "\n",
+    "import zakuro as zk\n",
+    "from sakura.huggingface import SakuraHFCallback\n",
+    "\n",
+    "print(\"torch:\", torch.__version__)\n",
+    "print(\"zakuro:\", zk.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Small model, small dataset — enough signal, minimal wall clock."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = \"distilbert-base-uncased\"\n",
+    "TRAIN_SIZE = 200\n",
+    "VAL_SIZE = 400\n",
+    "MAX_LENGTH = 64\n",
+    "EPOCHS = 3\n",
+    "BATCH_SIZE = 32\n",
+    "\n",
+    "config = AutoConfig.from_pretrained(MODEL_NAME, num_labels=2)\n",
+    "tok = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "\n",
+    "def _tokenize(batch):\n",
+    "    return tok(batch[\"sentence\"], padding=\"max_length\", truncation=True, max_length=MAX_LENGTH)\n",
+    "\n",
+    "raw = load_dataset(\"glue\", \"sst2\")\n",
+    "train = raw[\"train\"].shuffle(seed=42).select(range(TRAIN_SIZE)).map(_tokenize, batched=True)\n",
+    "val = raw[\"validation\"].shuffle(seed=42).select(range(min(VAL_SIZE, len(raw[\"validation\"])))).map(_tokenize, batched=True)\n",
+    "cols = [\"input_ids\", \"attention_mask\", \"label\"]\n",
+    "train.set_format(\"torch\", columns=cols)\n",
+    "val.set_format(\"torch\", columns=cols)\n",
+    "\n",
+    "val_payload = (\n",
+    "    {\n",
+    "        \"input_ids\": torch.stack([val[i][\"input_ids\"] for i in range(len(val))]).clone(),\n",
+    "        \"attention_mask\": torch.stack([val[i][\"attention_mask\"] for i in range(len(val))]).clone(),\n",
+    "        \"label\": torch.stack([val[i][\"label\"] for i in range(len(val))]).clone(),\n",
+    "    },\n",
+    "    BATCH_SIZE,\n",
+    ")\n",
+    "\n",
+    "def model_factory():\n",
+    "    return AutoModelForSequenceClassification.from_config(config)\n",
+    "\n",
+    "def eval_fn(model, payload):\n",
+    "    import torch as _t\n",
+    "    data, bs = payload\n",
+    "    device = _t.device(\"cpu\")\n",
+    "    model.to(device)\n",
+    "    correct = total = 0\n",
+    "    with _t.no_grad():\n",
+    "        for s in range(0, len(data[\"input_ids\"]), bs):\n",
+    "            batch = {k: data[k][s:s+bs].to(device) for k in (\"input_ids\",\"attention_mask\")}\n",
+    "            labels = data[\"label\"][s:s+bs].to(device)\n",
+    "            out = model(**batch, labels=labels)\n",
+    "            correct += int((out.logits.argmax(-1) == labels).sum().item())\n",
+    "            total += int(labels.size(0))\n",
+    "    return {\"val_acc\": correct / max(total, 1)}\n",
+    "\n",
+    "print(f\"train={len(train)}  val={len(val)}  epochs={EPOCHS}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def training_args(outdir: str, eval_strategy: str) -> TrainingArguments:\n",
+    "    return TrainingArguments(\n",
+    "        output_dir=outdir,\n",
+    "        num_train_epochs=EPOCHS,\n",
+    "        per_device_train_batch_size=BATCH_SIZE,\n",
+    "        per_device_eval_batch_size=BATCH_SIZE,\n",
+    "        eval_strategy=eval_strategy,\n",
+    "        save_strategy=\"no\",\n",
+    "        logging_strategy=\"no\",\n",
+    "        report_to=[],\n",
+    "        disable_tqdm=True,\n",
+    "        seed=42,\n",
+    "        dataloader_num_workers=0,\n",
+    "        fp16=torch.cuda.is_available(),\n",
+    "    )\n",
+    "\n",
+    "def run_with_callback(callback: SakuraHFCallback, label: str) -> dict:\n",
+    "    m = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)\n",
+    "    tr = Trainer(\n",
+    "        model=m,\n",
+    "        args=training_args(f\"/tmp/hf-features/{label}\", \"no\"),\n",
+    "        train_dataset=train,\n",
+    "        callbacks=[callback],\n",
+    "    )\n",
+    "    t0 = time.perf_counter()\n",
+    "    tr.train()\n",
+    "    wall = time.perf_counter() - t0\n",
+    "    return {\"label\": label, \"wall\": wall, \"history\": callback.history}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Baseline — default callback (lazy drain, cache on, in-memory handle auto-on for standalone)\n",
+    "\n",
+    "Every default knob in effect. `val_compute=None` so Zakuro falls back to standalone and the in-memory handle path kicks in automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cb = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=None,         # standalone fallback\n",
+    "    verbose=False,\n",
+    ")\n",
+    "baseline = run_with_callback(cb, \"defaults\")\n",
+    "print(f\"defaults: {baseline['wall']:.2f}s\")\n",
+    "for h in cb.history:\n",
+    "    print(f\"  epoch {int(h['epoch'])}: val_acc={h.get('val_acc'):.4f} took={h.get('elapsed_secs'):.2f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. `drain=\"strict\"` — block at every epoch boundary\n",
+    "\n",
+    "The lazy default (`drain=\"lazy\"`) never blocks training at `on_epoch_end` — it only reaps futures that are already done and pushes the rest through the pool. `strict` reverts to the pre-v0.2 behaviour: each epoch waits for the previous eval to finish. Useful when the caller wants metrics in epoch-order, at the cost of wall time whenever eval > train."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cb = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=None,\n",
+    "    drain=\"strict\",\n",
+    "    verbose=False,\n",
+    ")\n",
+    "strict = run_with_callback(cb, \"strict\")\n",
+    "print(f\"strict: {strict['wall']:.2f}s  (lazy was {baseline['wall']:.2f}s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `cache_key=None` — disable worker-side model cache\n",
+    "\n",
+    "By default the validator architecture is cached in a module-level dict keyed by `cache_key` (default `\"default\"`). Setting `cache_key=None` disables the cache; every epoch re-runs `model_factory()` on the worker. Shows the cost of *not* caching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cb = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=None,\n",
+    "    cache_key=None,  # rebuild every epoch\n",
+    "    verbose=False,\n",
+    ")\n",
+    "no_cache = run_with_callback(cb, \"no-cache\")\n",
+    "print(f\"no-cache: {no_cache['wall']:.2f}s  (cached was {baseline['wall']:.2f}s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `fp16_state_dict=True` — halve the bytes over the wire\n",
+    "\n",
+    "Not visible in standalone mode — the state_dict never hits the wire — but the tensor dtype conversion still happens. Useful over a real network for fp32 models. For this demo we just confirm the path runs end-to-end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cb = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=None,\n",
+    "    fp16_state_dict=True,\n",
+    "    verbose=False,\n",
+    ")\n",
+    "fp16 = run_with_callback(cb, \"fp16\")\n",
+    "print(f\"fp16: {fp16['wall']:.2f}s  (no-fp16 was {baseline['wall']:.2f}s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. `on_backpressure` + `AdaptiveCompute`\n",
+    "\n",
+    "Wrap the compute in `AdaptiveCompute` and flip the backpressure policy. With `on_backpressure=\"skip\"` the callback drops an epoch's eval whenever the allocator reports saturation — the epoch's `history` row is `{\"skipped\": True}`. We artificially mark the allocator as backpressured to exercise the path cheaply."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# An always-backpressured AdaptiveCompute for demonstration.\n",
+    "class AlwaysBackpressured(zk.AdaptiveCompute):\n",
+    "    def is_backpressured(self) -> bool:\n",
+    "        return True\n",
+    "\n",
+    "adaptive = AlwaysBackpressured(workers=[zk.Compute()], backpressure_threshold=0.001)\n",
+    "\n",
+    "cb = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=adaptive,\n",
+    "    on_backpressure=\"skip\",\n",
+    "    verbose=False,\n",
+    ")\n",
+    "skipped_run = run_with_callback(cb, \"bp-skip\")\n",
+    "print(f\"bp=skip: {skipped_run['wall']:.2f}s\")\n",
+    "print(\"history:\")\n",
+    "for h in cb.history:\n",
+    "    print(f\"  {h}\")\n",
+    "print(f\"skipped rows: {sum(1 for h in cb.history if h.get('skipped'))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. `async_copy` — CUDA-stream GPU→CPU snapshot\n",
+    "\n",
+    "Only relevant when the training model lives on CUDA. The cell below detects the device and reports what would happen; on a CPU/MPS laptop the sync path is used automatically (measured as 0 delta)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if torch.cuda.is_available():\n",
+    "    print(\"Running on CUDA — async_copy=True schedules the snapshot on a\")\n",
+    "    print(\"dedicated torch.cuda.Stream. Measured on x399 4090: 176→75ms main-thread/epoch.\")\n",
+    "    cb = SakuraHFCallback(\n",
+    "        model_factory=model_factory,\n",
+    "        eval_fn=eval_fn,\n",
+    "        eval_payload=val_payload,\n",
+    "        val_compute=None,\n",
+    "        async_copy=True,\n",
+    "        verbose=False,\n",
+    "    )\n",
+    "    async_run = run_with_callback(cb, \"async-copy\")\n",
+    "    print(f\"async_copy=True: {async_run['wall']:.2f}s\")\n",
+    "else:\n",
+    "    print(\"No CUDA here — async_copy falls back to the blocking .cpu() path.\")\n",
+    "    print(\"See /opt/code/ZAK/zakuro/PLAN.md for the x399 4090 measurement:\")\n",
+    "    print(\"  blocking .cpu()        : 176.1 ms/epoch main-thread\")\n",
+    "    print(\"  async CUDA-stream copy :  74.8 ms/epoch main-thread  (−57.5 %)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. In-memory handle (auto)\n",
+    "\n",
+    "When `val_compute` resolves to standalone (no URI, no host — which is the default when `val_compute=None`), the callback bypasses `torch.save`/`torch.load` entirely. The `state_dict` flows as a Python reference to the pool thread. Measured ~+24 % end-to-end wall on a 3-epoch distilbert standalone fine-tune (see `bert_demo/bench_in_memory_handle.py`).\n",
+    "\n",
+    "The toggle is automatic — no API surface. To force the remote-style path for comparison, monkey-patch the detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Forcing the torch.save path even though we're in-process.\n",
+    "cb = SakuraHFCallback(\n",
+    "    model_factory=model_factory,\n",
+    "    eval_fn=eval_fn,\n",
+    "    eval_payload=val_payload,\n",
+    "    val_compute=None,\n",
+    "    verbose=False,\n",
+    ")\n",
+    "cb._is_in_process_target = lambda: False  # force torch.save path\n",
+    "torch_save = run_with_callback(cb, \"torch-save\")\n",
+    "print(f\"torch.save path : {torch_save['wall']:.2f}s\")\n",
+    "print(f\"in-memory path  : {baseline['wall']:.2f}s\")\n",
+    "delta = torch_save['wall'] - baseline['wall']\n",
+    "print(f\"delta           : {delta:+.2f}s ({100*delta/torch_save['wall']:+.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = [\n",
+    "    (\"defaults (lazy drain, cache, in-memory handle)\", baseline[\"wall\"]),\n",
+    "    (\"drain=strict\", strict[\"wall\"]),\n",
+    "    (\"cache_key=None (re-instantiate each epoch)\", no_cache[\"wall\"]),\n",
+    "    (\"fp16_state_dict=True\", fp16[\"wall\"]),\n",
+    "    (\"on_backpressure=skip (AlwaysBackpressured)\", skipped_run[\"wall\"]),\n",
+    "    (\"forced torch.save (no in-memory shortcut)\", torch_save[\"wall\"]),\n",
+    "]\n",
+    "width = 55\n",
+    "print(f\"{'configuration':<{width}}  wall (s)\")\n",
+    "print(\"-\" * (width + 12))\n",
+    "for name, w in rows:\n",
+    "    print(f\"{name:<{width}}  {w:>7.2f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Old README described the MPI + Redis + SAKURA_ROLE flow we removed months ago and pointed at a `curl get.zakuro.ai/sakura/install` URL that no longer does anything useful.

New README covers the current Sakura:
- Zakuro-backed async dispatch (no MPI / Redis / SAKURA_ROLE, no subprocess fork).
- PyTorch Lightning (SakuraTrainer), HuggingFace (SakuraHFCallback), TensorFlow / Keras (SakuraKerasCallback).
- Every knob documented with a one-line description.
- Measured performance wins: async CUDA-stream copy (176 → 75 ms / epoch), torch.save over cloudpickle (482 → 282 ms, 39 → 72 % GIL share), in-memory-handle fast path (+23.6 % wall).
- Cross-links to `bert_demo/hf_async_features.ipynb` and to `zakuro/PLAN.md` for the consolidated measurement table.

## Test plan

- [x] Markdown renders cleanly on GitHub.
- [x] All 21 sakura tests still pass.
- [x] The linked notebook (`bert_demo/hf_async_features.ipynb`) runs end-to-end in ~1 min on Mac MPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)