### PR TITLE
chore: point zakuro-ai dep at master

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Zakuro replaces the former MPI + Redis transport: per-epoch validation
     # is dispatched to a Zakuro worker via @zk.fn instead of a second MPI rank.
     # Pulled from git until the 0.2.x series is published to PyPI.
-    "zakuro-ai @ git+https://github.com/zakuro-ai/zakuro.git@feat/adaptive-compute",
+    "zakuro-ai @ git+https://github.com/zakuro-ai/zakuro.git@master",
 ]
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
Leftover from a bench session where we temporarily pinned to `feat/adaptive-compute`. That branch has long since merged; the stale pin broke `uv pip install sakura-ml` when anything else also pulled zakuro@master.