### PR TITLE
ci: test + publish + auto-release workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,67 @@
+name: Auto-release
+
+# On master push: bump patch, tag, create release. publish.yml picks it
+# up and ships the wheel to PyPI.
+
+on:
+  push:
+    branches: [master, main]
+    paths-ignore:
+      - "**.md"
+      - "bert_demo/**.ipynb"
+      - "mnist_demo/**"
+      - ".github/workflows/*.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  bump-and-release:
+    if: "!contains(github.event.head_commit.message, '[skip release]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          set -euo pipefail
+          CURRENT=$(grep -E '^__version__ = ' sakura/__init__.py | sed -E 's/.*"([^"]+)".*/\1/')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          NEW="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "  current: $CURRENT"
+          echo "  new    : $NEW"
+          sed -i.bak -E "s/^__version__ = \".*\"/__version__ = \"$NEW\"/" sakura/__init__.py
+          sed -i.bak -E "s/^version = \".*\"/version = \"$NEW\"/" pyproject.toml
+          rm sakura/__init__.py.bak pyproject.toml.bak
+          echo "new_version=$NEW" >> "$GITHUB_OUTPUT"
+          echo "tag=v$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Commit + tag
+        run: |
+          set -euo pipefail
+          git add sakura/__init__.py pyproject.toml
+          git commit -m "chore(release): v${{ steps.bump.outputs.new_version }} [skip release]"
+          git tag "${{ steps.bump.outputs.tag }}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.bump.outputs.tag }}" \
+            --title "${{ steps.bump.outputs.tag }}" \
+            --generate-notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-pypi:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build wheel
+        run: |
+          uv venv .venv
+          uv pip install --python .venv/bin/python hatchling build
+          .venv/bin/python -m build --wheel --outdir dist
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install package + test deps
+        run: |
+          uv venv .venv
+          uv pip install --python .venv/bin/python -e '.[huggingface]' pytest
+
+      - name: Run tests
+        run: .venv/bin/pytest tests/ -v


### PR DESCRIPTION
## Summary

Full CI stack for Sakura (previously had none):

- **`test.yml`** — pytest matrix across Python 3.10 / 3.11 / 3.12 on every PR + master push.
- **`publish.yml`** — fires on `release: published`, builds the wheel, publishes to PyPI via Trusted Publishing (OIDC — no API token needed once the project is configured in PyPI admin).
- **`auto-release.yml`** — on master push, bumps `__version__` in `sakura/__init__.py` and `version` in `pyproject.toml`, tags, creates a release, which triggers publish.yml.

## Skips

- `[skip release]` in commit message (so the bump commit itself doesn't recurse).
- Docs-only / notebook-only / mnist_demo-only / CI-only pushes.

## Setup note

For PyPI Trusted Publishing to work on the first release, add the repo as a trusted publisher on PyPI:
https://pypi.org/manage/account/publishing/ → Add a new pending publisher → owner `zakuro-ai`, repo `sakura`, workflow `publish.yml`, environment `release`.

Alternative: swap the `pypa/gh-action-pypi-publish` step for a username/password (TWINE_USERNAME=__token__, TWINE_PASSWORD=${{ secrets.PYPI_API_TOKEN }}) equivalent to the zakuro repo setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
