### PR TITLE
fix: PyPI dep + switch publish to API token

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -76,8 +76,6 @@ jobs:
     needs: bump-and-release
     runs-on: ubuntu-latest
     environment: release
-    permissions:
-      id-token: write  # OIDC trusted publishing — no token secret needed
     steps:
       - uses: actions/checkout@v4
         with:
@@ -92,10 +90,17 @@ jobs:
       - name: Build wheel + sdist
         run: |
           uv venv .venv
-          uv pip install --python .venv/bin/python hatchling build
+          uv pip install --python .venv/bin/python hatchling build twine
           .venv/bin/python -m build --outdir dist
 
-      - name: Publish to PyPI (trusted publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
+      - name: Publish to PyPI (API token)
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TWINE_PASSWORD:-}" ]; then
+            echo "::error::PYPI_API_TOKEN secret is not set on the 'release' environment."
+            exit 1
+          fi
+          .venv/bin/python -m twine upload dist/* --non-interactive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ dependencies = [
     "charset-normalizer==3.1.0",
     # Zakuro replaces the former MPI + Redis transport: per-epoch validation
     # is dispatched to a Zakuro worker via @zk.fn instead of a second MPI rank.
-    # Pulled from git until the 0.2.x series is published to PyPI.
-    "zakuro-ai @ git+https://github.com/zakuro-ai/zakuro.git@master",
+    "zakuro-ai>=0.2.3",
 ]
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary

Two fixes that together unblock sakura's PyPI publish:

1. **deps**: drop `zakuro-ai @ git+...` (PyPI rejects direct-URL deps with `400 Can't have direct dependency`) in favour of `zakuro-ai>=0.2.3` now that zakuro-ai is on PyPI.
2. **ci**: switch publish step from OIDC trusted publishing to twine + `PYPI_API_TOKEN` (trusted publishing wasn't configured on PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
