### PR TITLE
Add fast CPU-only integration and regression tests, modernise CLI, and stabilise Trainer workflows across Lightning and Hugging Face

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ classifiers = [
 huggingface = [
     "transformers>=4.40.0",
     "datasets>=2.14.0",
+    "accelerate>=1.1.0",
 ]
 tensorflow = [
     "tensorflow>=2.15.0",
 ]
 bench = [
     "sakura-ml[huggingface]",
-    "accelerate>=0.25.0",
 ]
 
 [dependency-groups]

--- a/sakura/__main__.py
+++ b/sakura/__main__.py
@@ -1,22 +1,43 @@
-import os
-import sys
+"""Light-weight CLI for Sakura.
 
-ascii_txt = """\
-   _____           _                               __  __   _      
-  / ____|         | |                             |  \/  | | |     
- | (___     __ _  | | __  _   _   _ __    __ _    | \  / | | |     
-  \___ \   / _` | | |/ / | | | | | '__|  / _` |   | |\/| | | |     
-  ____) | | (_| | |   <  | |_| | | |    | (_| |   | |  | | | |____ 
- |_____/   \__,_| |_|\_\  \__,_| |_|     \__,_|   |_|  |_| |______|
+The package's primary interface is its Python APIs; the top-level CLI is an
+informational entry point rather than a training orchestrator.
 """
 
+from __future__ import annotations
 
-def main():
-    print(ascii_txt)
-    os.system(
-        f"mpirun --mca btl_base_warn_component_unused 0 -np 2 python -W ignore {' '.join(sys.argv[1:])}"
+import argparse
+from typing import Sequence
+
+from sakura import __build__, __version__
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(
+        prog="sakura",
+        description=(
+            "Sakura provides Zakuro-backed asynchronous evaluation integrations "
+            "for Lightning, HuggingFace Trainer, and TensorFlow/Keras."
+        ),
+        epilog=(
+            "Use the Python APIs from sakura.lightning, sakura.huggingface, or "
+            "sakura.tensorflow. The bundled benchmark entry point is "
+            "`sakura-benchmark`."
+        ),
     )
 
 
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__} (build {__build__})",
+    )
+    parser.parse_args(argv)
+    parser.print_help()
+    return 0
+
+
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+class TestSakuraCli:
+    def test_module_help_is_non_destructive(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "sakura"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert "Zakuro-backed asynchronous evaluation" in result.stdout
+        assert "sakura-benchmark" in result.stdout
+        assert "mpirun" not in result.stdout
+        assert "mpirun" not in result.stderr
+
+    def test_module_version(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "sakura", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert result.stdout.startswith("sakura ")
+        assert "build" in result.stdout

--- a/tests/test_huggingface_e2e.py
+++ b/tests/test_huggingface_e2e.py
@@ -1,0 +1,120 @@
+"""End-to-end smoke test for SakuraHFCallback with a real Trainer."""
+
+from __future__ import annotations
+
+import pytest
+
+transformers = pytest.importorskip("transformers")
+torch = pytest.importorskip("torch")
+pytest.importorskip("accelerate")
+
+from sakura.huggingface import SakuraHFCallback
+
+
+def _tiny_bert_config():
+    return transformers.BertConfig(
+        vocab_size=32,
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        intermediate_size=32,
+        max_position_embeddings=32,
+        num_labels=2,
+        hidden_dropout_prob=0.0,
+        attention_probs_dropout_prob=0.0,
+    )
+
+
+class _TinyDataset(torch.utils.data.Dataset):
+    def __init__(self, sample_count: int) -> None:
+        self._rows = []
+        for index in range(sample_count):
+            label = index % 2
+            input_ids = torch.tensor(
+                [1, 2, 3, label + 4, 0, 0, 0, 0], dtype=torch.long
+            )
+            attention_mask = (input_ids != 0).long()
+            self._rows.append(
+                {
+                    "input_ids": input_ids,
+                    "attention_mask": attention_mask,
+                    "labels": torch.tensor(label, dtype=torch.long),
+                }
+            )
+
+    def __len__(self) -> int:
+        return len(self._rows)
+
+    def __getitem__(self, index: int):
+        row = self._rows[index]
+        return {key: value.clone() for key, value in row.items()}
+
+
+def _hf_model_factory():
+    return transformers.BertForSequenceClassification(_tiny_bert_config())
+
+
+def _hf_eval_fn(model, payload) -> dict:
+    with torch.no_grad():
+        logits = model(
+            input_ids=payload["input_ids"],
+            attention_mask=payload["attention_mask"],
+        ).logits
+        predictions = logits.argmax(dim=-1)
+    labels = payload["labels"]
+    accuracy = float((predictions == labels).float().mean().item())
+    return {"val_acc": accuracy}
+
+
+class TestSakuraHFTrainerEndToEnd:
+    def test_real_trainer_run_records_eval_metrics(self, tmp_path):
+        torch.manual_seed(0)
+        train_dataset = _TinyDataset(sample_count=8)
+        eval_dataset = _TinyDataset(sample_count=4)
+        eval_payload = {
+            "input_ids": torch.stack(
+                [eval_dataset[index]["input_ids"] for index in range(len(eval_dataset))]
+            ),
+            "attention_mask": torch.stack(
+                [
+                    eval_dataset[index]["attention_mask"]
+                    for index in range(len(eval_dataset))
+                ]
+            ),
+            "labels": torch.stack(
+                [eval_dataset[index]["labels"] for index in range(len(eval_dataset))]
+            ),
+        }
+
+        callback = SakuraHFCallback(
+            model_factory=_hf_model_factory,
+            eval_fn=_hf_eval_fn,
+            eval_payload=eval_payload,
+            cache_key=None,
+            verbose=False,
+        )
+        model = _hf_model_factory()
+        trainer = transformers.Trainer(
+            model=model,
+            args=transformers.TrainingArguments(
+                output_dir=str(tmp_path / "hf-smoke"),
+                num_train_epochs=1,
+                per_device_train_batch_size=2,
+                eval_strategy="no",
+                save_strategy="no",
+                logging_strategy="no",
+                report_to=[],
+                disable_tqdm=True,
+                seed=0,
+                dataloader_num_workers=0,
+            ),
+            train_dataset=train_dataset,
+            callbacks=[callback],
+        )
+
+        trainer.train()
+
+        assert len(callback.history) == 1
+        assert callback.history[0]["epoch"] == 1
+        assert 0.0 <= callback.history[0]["val_acc"] <= 1.0
+        assert "elapsed_secs" in callback.history[0]

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -1,0 +1,65 @@
+"""Smoke test for the Lightning integration."""
+
+from __future__ import annotations
+
+import pytest
+
+lightning = pytest.importorskip("lightning")
+torch = pytest.importorskip("torch")
+
+from torch.utils.data import DataLoader, TensorDataset
+
+from sakura.lightning import SakuraTrainer
+
+
+class _TinyModule(lightning.LightningModule):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer = torch.nn.Linear(4, 2)
+
+    def forward(self, x):
+        return self.layer(x)
+
+    def training_step(self, batch, batch_idx):  # noqa: ARG002
+        x, y = batch
+        logits = self(x)
+        return torch.nn.functional.cross_entropy(logits, y)
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.parameters(), lr=0.1)
+
+
+def _make_loader(sample_count: int) -> DataLoader:
+    features = torch.randn(sample_count, 4)
+    targets = torch.randint(0, 2, (sample_count,))
+    return DataLoader(TensorDataset(features, targets), batch_size=4)
+
+
+class TestSakuraLightningTrainer:
+    def test_run_records_async_validation_history(self):
+        """Training should complete and record standalone validation metrics."""
+        torch.manual_seed(0)
+        train_loader = _make_loader(8)
+        val_loader = _make_loader(8)
+
+        trainer = SakuraTrainer(
+            max_epochs=1,
+            accelerator="cpu",
+            devices=1,
+            logger=False,
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            model_factory=_TinyModule,
+            val_loader_factory=lambda: val_loader,
+            verbose=False,
+        )
+
+        model = _TinyModule()
+        trained = trainer.run(model, train_loader)
+
+        assert trained is model
+        assert len(trainer.history) == 1
+        assert trainer.history[0]["worker_name"] == "<standalone>"
+        assert trainer.history[0]["val_loss"] >= 0
+        assert trainer.best_val_loss == trainer.history[0]["val_loss"]

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -1,0 +1,80 @@
+"""Tests for the TensorFlow / Keras integration without requiring TensorFlow."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+class _FakeKerasModel:
+    def __init__(self) -> None:
+        self._weights = [0.0, 0.0]
+
+    def get_weights(self):
+        return list(self._weights)
+
+    def set_weights(self, weights):
+        self._weights = list(weights)
+
+
+def _fake_model_factory():
+    return _FakeKerasModel()
+
+
+def _fake_val_fn(model, payload) -> dict:
+    offset = payload
+    total = sum(model.get_weights())
+    return {
+        "val_loss": float(total + offset),
+        "val_acc": float(total / 10.0),
+    }
+
+
+def _load_tensorflow_module(monkeypatch):
+    fake_tensorflow = types.ModuleType("tensorflow")
+    fake_keras = types.ModuleType("tensorflow.keras")
+    fake_callbacks = types.ModuleType("tensorflow.keras.callbacks")
+
+    class _FakeCallback:
+        def __init__(self) -> None:
+            self.model = None
+
+    fake_callbacks.Callback = _FakeCallback
+    fake_keras.callbacks = fake_callbacks
+    fake_tensorflow.keras = fake_keras
+
+    monkeypatch.setitem(sys.modules, "tensorflow", fake_tensorflow)
+    monkeypatch.setitem(sys.modules, "tensorflow.keras", fake_keras)
+    monkeypatch.setitem(sys.modules, "tensorflow.keras.callbacks", fake_callbacks)
+    sys.modules.pop("sakura.tensorflow", None)
+    return importlib.import_module("sakura.tensorflow")
+
+
+class TestSakuraKerasCallback:
+    def test_dispatches_and_records_metrics(self, monkeypatch):
+        module = _load_tensorflow_module(monkeypatch)
+        callback = module.SakuraKerasCallback(
+            model_factory=_fake_model_factory,
+            val_fn=_fake_val_fn,
+            val_payload=1.0,
+            verbose=False,
+        )
+        callback.model = _FakeKerasModel()
+
+        callback.model.set_weights([2.0, 4.0])
+        callback.on_epoch_end(0)
+
+        callback.model.set_weights([1.0, 1.0])
+        callback.on_epoch_end(1)
+        callback.on_train_end()
+
+        assert len(callback.history) == 2
+        assert callback.history[0]["epoch"] == 0
+        assert callback.history[0]["val_loss"] == 7.0
+        assert callback.history[0]["val_acc"] == 0.6
+        assert callback.history[1]["epoch"] == 1
+        assert callback.history[1]["val_loss"] == 3.0
+        assert callback.history[1]["val_acc"] == 0.2
+        for row in callback.history:
+            assert "elapsed_secs" in row

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -1,0 +1,74 @@
+"""Worker-backed integration test for the Zakuro transport path."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("uvicorn")
+pytest.importorskip("fastapi")
+
+from zakuro.worker.runner import Worker
+
+from sakura.ml.async_trainer import AsyncTrainer
+
+
+class _Metrics:
+    def __init__(self) -> None:
+        self.test: dict = {}
+
+
+class _FakeTrainer:
+    def __init__(self, epochs: int) -> None:
+        self._epochs = list(range(epochs))
+        self._epoch = 0
+        self._metrics = _Metrics()
+        self._value = 40
+
+    def serialized_state_dict(self) -> dict:
+        return {"value": self._value}
+
+    def train(self, train_loader=None):  # noqa: ARG002
+        self._value += 1
+
+
+class _WorkerModel:
+    def __init__(self) -> None:
+        self.state_dict_data: dict = {}
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        self.state_dict_data = dict(state_dict)
+
+
+def _worker_model_factory():
+    return _WorkerModel()
+
+
+def _worker_test_fn(model) -> dict:
+    return {
+        "value": model.state_dict_data["value"],
+        "worker_pid": os.getpid(),
+    }
+
+
+class TestWorkerBackedAsyncTrainer:
+    def test_dispatches_to_real_http_worker(self):
+        trainer = _FakeTrainer(epochs=2)
+
+        try:
+            worker = Worker.spawn(name="sakura-pytest-worker", transport="http")
+        except PermissionError as exc:
+            pytest.skip(f"worker integration requires local socket permissions: {exc}")
+
+        with worker:
+            async_trainer = AsyncTrainer(
+                trainer=trainer,
+                model_factory=_worker_model_factory,
+                test_fn=_worker_test_fn,
+                val_compute=worker.compute(),
+            )
+            async_trainer.run()
+
+        assert trainer._metrics.test["value"] == 42
+        assert trainer._metrics.test["worker_pid"] != os.getpid()


### PR DESCRIPTION
- Add a minimal integration test for SakuraTrainer
- Validate the standalone PyTorch Lightning workflow described in the README
- Ensure tests remain fast, self-contained, and CPU-only
- Replace the outdated mpirun-based Sakura CLI with a safe informational CLI
- Introduce regression tests for the CLI and TensorFlow callback behaviour without requiring TensorFlow
- Add end-to-end Hugging Face Trainer smoke tests and prevent shared callback cache issues
- Include an async, worker-backed trainer integration test with a sandbox-aware skip fallback
- Move accelerate to the Hugging Face extra to ensure Trainer workflows install correctly