### PR TITLE
fix: README setup issues and pytest collection failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ cd sakura
 # Copy environment template
 cp .env.template .env
 
+# Create a virtual environment with a supported Python version.
+# PyTorch wheels are not yet published for Python 3.13+, so pin to 3.12.
+uv venv --python 3.12
+source .venv/bin/activate
+
 # Install in editable mode
 uv pip install -e .
 ```
@@ -184,9 +189,12 @@ python3 main.py --mode baseline
 
 ### Using the Sakura CLI
 
+The `sakura` command is an informational entry point — it prints help and exits.
+To run the bundled benchmark from the CLI, use `sakura-benchmark`:
+
 ```bash
-# Launch Sakura via the CLI entry point
-sakura main.py
+# Run the benchmark via the bundled entry point (equivalent to `python3 main.py`)
+sakura-benchmark --mode sakura --epochs 10
 ```
 
 You should be able to see this output with no delay between epochs (asynchronous testing).
@@ -223,4 +231,4 @@ docker exec -it sakura bash
 
 # Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed list of changes.
+See the [GitHub releases page](https://github.com/zakuro-ai/sakura/releases) for a detailed list of changes.

--- a/tests/test_ddp.py
+++ b/tests/test_ddp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")  # sakura.ddp imports sakura.huggingface
 
 from sakura.ddp import DDPAsyncEvalCallback
 


### PR DESCRIPTION
## Summary

Hit a few issues running through the standalone setup on a fresh macOS box.
All small — README clarifications plus one test-collection fix.

- **README**: pin Python to 3.12 in the install steps. On Python 3.13+ the
  install fails because PyTorch wheels aren't published for those versions
  yet, and `requires-python = ">=3.10"` lets users land on an unsupported
  interpreter by default.
- **README**: the `sakura main.py` example doesn't train — `sakura/__main__.py`
  is documented as an informational entry point and just prints help. Swapped
  in `sakura-benchmark`, which is the actual entry point exposed by
  `[project.scripts]`.
- **README**: `[CHANGELOG.md](CHANGELOG.md)` 404s (no such file in the repo).
  Linked to the GitHub releases page instead.
- **tests/test_ddp.py**: `pytest` fails at *collection* on a default install
  because `sakura.ddp` transitively imports `sakura.huggingface`, which
  raises `ImportError` without the optional `[huggingface]` extra. Added
  `pytest.importorskip("transformers")` so the suite skips cleanly.

## Test plan

- [x] `uv venv --python 3.12 && uv pip install -e .` on macOS
- [x] `python main.py --mode sakura --epochs 1` — runs, validates via `zakuro standalone (in-process)`
- [x] `pytest -q` — 24 passed, 4 skipped (was: collection error)
- [x] `sakura-benchmark --help` — entry point exists and works