### PR TITLE
plugin: add AI coding agent plugin POC

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -1,14 +1,24 @@
-name: CI
+name: plugin
 
 on:
   pull_request:
+    paths:
+      - "zakuro-poc-plugin/**"
+      - ".github/workflows/plugin.yml"
   push:
     branches:
-      - main
+      - master
+      - plugin
+    paths:
+      - "zakuro-poc-plugin/**"
+      - ".github/workflows/plugin.yml"
 
 jobs:
   python-checks:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: zakuro-poc-plugin
 
     steps:
       - name: Checkout
@@ -43,6 +53,9 @@ jobs:
 
   docker-smoke:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: zakuro-poc-plugin
 
     steps:
       - name: Checkout

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -35,14 +35,14 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 
 ### Workstream: AI Execution Plugin (`zakuro-poc-plugin`)
 - **Purpose:** Allow Claude/Codex to safely translate natural language intent into executed compute jobs.
-- **Concrete Outputs:** Pydantic schemas, explicit security policies (no raw shell, no network by default), abstract `ExecutionBackend`, isolated `DockerBackend`, Typer CLI wrapper (`validate`, `plan-show`, `execute`), Claude `SKILL.md`, root GitHub Actions workflow, structured artefact handling, Docker non-root defaults, a fake backend contract suite, a `ZakuroBackend` subprocess adapter for `zc execute`, and plugin-specific docs.
-- **Evidence of Completion:** Local plugin suite passes with `105 passed` and `100%` coverage for `zakuro_poc`; Docker-backed integration tests pass against a reachable daemon; lint, type-check, and diff checks pass.
-- **Current Status:** Implemented POC, complete with limitations. The plugin is functionally complete as a local execution scaffold, but it still depends on an external `zc` runtime contract for the native Zakuro path.
+- **Concrete Outputs:** Pydantic schemas, explicit security policies (no raw shell, no network by default), abstract `ExecutionBackend`, isolated `DockerBackend`, Typer CLI wrapper (`validate`, `plan-show`, `execute`), Claude `SKILL.md`, root GitHub Actions workflow, structured artefact handling (with concurrency safety), Docker non-root defaults, a fake backend contract suite (with failure normalisation), a `ZakuroBackend` subprocess adapter for `zc execute`, formal threat model documentation (`THREAT_MODEL.md`), and plugin-specific docs.
+- **Evidence of Completion:** Local plugin suite passes with `102 passed` and `100%` coverage for `zakuro_poc` (including strict tests for `zc` JSON panics); Docker-backed integration tests pass against a reachable daemon; agent workflows enforce validation without bypasses; lint, type-check, and diff checks pass.
+- **Current Status:** Implemented POC, complete with limitations. The plugin is functionally complete and secure as a local execution scaffold, but it still depends on an external `zc` runtime contract for the native Zakuro path.
 
 ## 5. Current State
 - **Zakuro Runtime:** In progress.
 - **Sakura Services:** In progress.
-- **Zakuro POC Plugin:** Implemented POC, locally validated, complete with limitations.
+- **Zakuro POC Plugin:** Implemented POC, locally validated and security-hardened, complete with limitations.
 - **Rust Broker (`zc`):** Partially implemented / External dependency.
 - **Federated Marketplace / Billing:** Deferred.
 
@@ -59,7 +59,7 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 
 ## 7. Risks and Open Questions
 - **Product Identity Drift:** The project oscillates between being a Python ML optimizer, a distributed worker runtime, and a federated compute marketplace. Marketing these simultaneously risks diluting the core developer value proposition.
-- **Security Posture (Cloudpickle):** Shipping functions via `cloudpickle` inherently carries severe code execution risks. The runtime requires a hardened zero-trust isolation model before enterprise multi-tenant deployments can be certified.
+- **Security Posture (Cloudpickle):** Shipping functions via `cloudpickle` inherently carries severe code execution risks. The runtime requires a hardened zero-trust isolation model before enterprise multi-tenant deployments can be certified, as formally outlined in the plugin's `THREAT_MODEL.md`.
 - **Framework Overreach:** Supporting raw PyTorch DDP, Lightning, Hugging Face, Ray, Dask, and Spark simultaneously creates an enormous maintenance and compatibility surface area for an early-stage team.
 - **GPU Async Validation:** AsyncEval is highly effective for CPU workloads where eval cost approximates training cost, but blocks on heavily GPU-bound workloads. Stream-based GPU dispatchers are required.
 
@@ -69,7 +69,7 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 |------------|----------------|----------|----------------|------------|-------------------------|
 | **Sakura Services** | In Progress (v1.0a1) | Reproducible bench harness, NCCL correctness tests | Stream-based GPU dispatchers, expanded multi-task workloads | Medium | Finalize v1.0.0 release. |
 | **Zakuro Runtime** | In Progress (v0.3) | `AdaptiveCompute` drift detection and QUIC transport implemented | Transition from standalone clusters to Rust broker mesh | Low | Stabilize worker API and QUIC reliability. |
-| **Zakuro POC Plugin** | Implemented POC, complete with limitations | Structured models, CLI, Docker backend, Claude/Codex guidance, root CI, fake backend contract tests, `ZakuroBackend` adapter, `100%` local coverage | Replace subprocess-based native backend with deeper `zc` integration once the broker contract is stable | Medium | Stabilise the `zc` contract and decide whether a native backend API is worth the complexity. |
+| **Zakuro POC Plugin** | Implemented POC, complete with limitations | Structured models, CLI, Docker backend, hardened agent guidance, root CI, robust mock tests for `zc` failure modes, `THREAT_MODEL.md`, `100%` local coverage | Replace subprocess-based native backend with deeper `zc` integration once the broker contract is stable | Medium | Stabilise the `zc` contract and decide whether a native backend API is worth the complexity. |
 | **Federated Marketplace** | Deferred | Mentioned in PRD/Memos, lack of active ledger codebase | Billing, identity, SLA enforcement, Dashboard | High | Keep deferred until runtime adoption is proven. |
 
 ## 9. Recommended Next Steps

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,81 @@
+# Strategy Memo: Zakuro AI Project
+
+## 1. Executive Summary
+The Zakuro project has evolved from a simple Python ML helper library (Sakura) into a sophisticated context-aware distributed-ML runtime (Zakuro) paired with an asynchronous ML training services layer (Sakura v1.0). The original commercial vision depicted a federated fog-compute marketplace, but the immediate engineering focus has successfully narrowed to delivering a robust, adaptive developer runtime that decouples ML training from blocking operations (evaluation, checkpointing) via a QUIC-backed transport and rust-based optimizations.
+
+The project is technically sound, demonstrating rigorous benchmarking and a healthy engineering culture focused on isolating and measuring distributed failure modes. The recent addition of the `zakuro-poc-plugin` successfully bridges AI coding agents (Claude/Codex) into this ecosystem by establishing a secure, verifiable execution pipeline (`Intent -> Plan -> Consent -> Isolated Backend -> Observable Result`).
+
+The main achievement is the concrete separation of the ML training layer (Sakura) from the execution substrate (Zakuro) and the successful abstraction of the execution backend via the new AI plugin. The largest remaining work lies in maturing the Rust broker (`zc`) and bridging the current developer-runtime into the broader marketplace vision (billing, enterprise isolation).
+
+## 2. Original Intent
+- **Problem:** ML training loops block synchronously on side-tasks like evaluation, checkpointing, and logging, wasting expensive GPU cycles. Furthermore, distributed execution requires complex manual routing and rigid infrastructure.
+- **Intended Outcome:** A federated compute marketplace and distributed runtime where Python functions can seamlessly execute remotely, with an intelligent mesh adaptively routing workloads based on latency, cost, and availability.
+- **Success Criteria:** Measurable reductions in ML training wall-clock time via async services; verifiable multi-rank optimization correctness; secure remote execution from AI agents; and eventual sub-cent billing for a federated marketplace.
+- **Intent Evolution:** The commercial "marketplace" vision (billing, ledger, providers) has been temporarily deferred in favor of a highly focused technical wedge: building a world-class, adaptive distributed ML developer runtime and asynchronous training services library.
+
+## 3. Project Evolution
+- **Phase 0 (2023):** Early ML-library experiments (Sakura v0.1).
+- **Phase 1 (2025 - Early 2026):** Zakuro emerges as a distributed compute substrate. Experiments with Tailscale, mesh setups, and Docker worker nodes.
+- **Phase 2 (April 2026):** Strategic pivot toward adaptive allocation (`AdaptiveCompute`) and QUIC transport over HTTP. Rejection of manual routing strategies in favor of context-aware telemetry (latency drift, dead connections).
+- **Phase 3 (May 2026):** Sakura v1.0 alpha introduces `SakuraRuntime`, decoupling async eval/checkpointing using the QUIC worker transport. Strong focus on benchmark credibility (ZeRO-1 multi-rank, fp16/bf16 scaling on RTX 4090).
+- **Phase 4 (Current):** Implementation of the `zakuro-poc-plugin`. Establishing a controlled, structured execution boundary enabling LLMs to safely orchestrate compute tasks within isolated Docker backends, acting as a precursor for the Rust `zc` broker.
+
+## 4. Completed Work
+
+### Workstream: Core Zakuro Substrate
+- **Purpose:** Provide the foundational distributed execution runtime.
+- **Concrete Outputs:** `@zk.fn` decorators, HTTP/QUIC workers, local fallback modes, `AdaptiveCompute` (Adam-style EMAs for latency and variance tracking).
+- **Current Status:** In progress / Complete with limitations (version ~0.3-draft). Focus is on execution mechanics, not yet marketplace billing.
+
+### Workstream: Sakura ML Training Services
+- **Purpose:** Accelerate PyTorch/Lightning/HF training via decoupled services.
+- **Concrete Outputs:** `SakuraRuntime`, `MixedPrecision`, `ZeRO1`, `AsyncEval`, `AsyncCheckpoint`.
+- **Evidence:** Verified GPU benchmarks (e.g., 1.32x speedup on ResNet-50, 1.57x speedup on MNIST CPU via overlapped async eval).
+- **Current Status:** In progress (version 1.0.0a1). Benchmarking and correctness validation heavily prioritized.
+
+### Workstream: AI Execution Plugin (`zakuro-poc-plugin`)
+- **Purpose:** Allow Claude/Codex to safely translate natural language intent into executed compute jobs.
+- **Concrete Outputs:** Pydantic schemas, explicit security policies (no raw shell, no network by default), abstract `ExecutionBackend`, isolated `DockerBackend`, Typer CLI wrapper (`validate`, `plan-show`, `execute`), and Claude `SKILL.md`.
+- **Current Status:** Complete. Fully tested and CI-gated. 
+
+## 5. Current State
+- **Zakuro Runtime:** In progress.
+- **Sakura Services:** In progress.
+- **Zakuro POC Plugin:** Complete.
+- **Rust Broker (`zc`):** Partially implemented / External dependency.
+- **Federated Marketplace / Billing:** Deferred.
+
+## 6. Remaining Work
+- **Transition POC Plugin to Zakuro Backend:** 
+  - *What:* Swap the `DockerBackend` abstraction in the `zakuro-poc-plugin` to utilize `zk.Compute` or `zc execute`.
+  - *Why:* To fully integrate the AI agent workflow into the native Zakuro distributed mesh instead of a local Docker simulation.
+- **Mature the Rust Broker (`zc`):**
+  - *What:* Finalize the high-performance Rust control plane.
+  - *Why:* Required to scale beyond local clusters and hit the 10-50K RPS targets for the federated mesh.
+- **Marketplace & Billing Infrastructure:**
+  - *What:* Re-introduce enterprise billing, PostgreSQL ledgers, and SLA compliance models.
+  - *Why:* Necessary to realize the ultimate commercial vision outlined in the investor memo.
+
+## 7. Risks and Open Questions
+- **Product Identity Drift:** The project oscillates between being a Python ML optimizer, a distributed worker runtime, and a federated compute marketplace. Marketing these simultaneously risks diluting the core developer value proposition.
+- **Security Posture (Cloudpickle):** Shipping functions via `cloudpickle` inherently carries severe code execution risks. The runtime requires a hardened zero-trust isolation model before enterprise multi-tenant deployments can be certified.
+- **Framework Overreach:** Supporting raw PyTorch DDP, Lightning, Hugging Face, Ray, Dask, and Spark simultaneously creates an enormous maintenance and compatibility surface area for an early-stage team.
+- **GPU Async Validation:** AsyncEval is highly effective for CPU workloads where eval cost approximates training cost, but blocks on heavily GPU-bound workloads. Stream-based GPU dispatchers are required.
+
+## 8. Status Matrix
+
+| Workstream | Current Status | Evidence | Remaining Work | Risk Level | Recommended Next Action |
+|------------|----------------|----------|----------------|------------|-------------------------|
+| **Sakura Services** | In Progress (v1.0a1) | Reproducible bench harness, NCCL correctness tests | Stream-based GPU dispatchers, expanded multi-task workloads | Medium | Finalize v1.0.0 release. |
+| **Zakuro Runtime** | In Progress (v0.3) | `AdaptiveCompute` drift detection and QUIC transport implemented | Transition from standalone clusters to Rust broker mesh | Low | Stabilize worker API and QUIC reliability. |
+| **Zakuro POC Plugin** | Complete | Passing CI, strict security policies, functional Docker Backend | Swap `DockerBackend` for `ZakuroBackend` / `zc execute` | Low | Connect POC to live Zakuro cluster. |
+| **Federated Marketplace** | Deferred | Mentioned in PRD/Memos, lack of active ledger codebase | Billing, identity, SLA enforcement, Dashboard | High | Keep deferred until runtime adoption is proven. |
+
+## 9. Recommended Next Steps
+- **Immediate:** Integrate the completed `zakuro-poc-plugin` with the existing `zakuro` python runtime, allowing the AI agent to dispatch tasks via `zk.Compute` rather than raw Docker.
+- **Short-Term:** Solidify `sakura`'s GPU asynchronous dispatch mechanisms to prevent blocking on heavily GPU-bound evaluation workloads.
+- **Medium-Term:** Mature the `zc` Rust broker and transition the orchestration layer off Python `subprocess` into native Rust mesh management.
+- **Deferred:** Enterprise marketplace billing and provider liquidity generation.
+
+## 10. Final Assessment
+The project is on track and making excellent technical decisions by narrowing its focus from a grandiose marketplace to a highly optimized, measurable distributed ML runtime. The largest gap is the missing integration between the newly minted AI execution plugin and the actual native Zakuro distributed mesh. The largest risk is maintaining focus across too many supported ML frameworks and failing to adequately secure the Python serialization boundaries for enterprise deployment. The immediate next step is to hook the `zakuro-poc-plugin` into `zk.Compute` to complete the ecosystem loop.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -3,9 +3,9 @@
 ## 1. Executive Summary
 The Zakuro project has evolved from a simple Python ML helper library (Sakura) into a sophisticated context-aware distributed-ML runtime (Zakuro) paired with an asynchronous ML training services layer (Sakura v1.0). The original commercial vision depicted a federated fog-compute marketplace, but the immediate engineering focus has successfully narrowed to delivering a robust, adaptive developer runtime that decouples ML training from blocking operations (evaluation, checkpointing) via a QUIC-backed transport and rust-based optimizations.
 
-The project is technically sound, demonstrating rigorous benchmarking and a healthy engineering culture focused on isolating and measuring distributed failure modes. The recent addition of the `zakuro-poc-plugin` successfully bridges AI coding agents (Claude/Codex) into this ecosystem by establishing a secure, verifiable execution pipeline (`Intent -> Plan -> Consent -> Isolated Backend -> Observable Result`).
+The project is technically sound, demonstrating rigorous benchmarking and a healthy engineering culture focused on isolating and measuring distributed failure modes. The recent addition of the `zakuro-poc-plugin` establishes the first AI-agent execution boundary for Claude/Codex, but it should be treated as an implemented POC rather than a complete production component. Its intended pipeline is `Intent -> Plan -> Validation -> Consent -> Isolated Backend -> Observable Result`.
 
-The main achievement is the concrete separation of the ML training layer (Sakura) from the execution substrate (Zakuro) and the successful abstraction of the execution backend via the new AI plugin. The largest remaining work lies in maturing the Rust broker (`zc`) and bridging the current developer-runtime into the broader marketplace vision (billing, enterprise isolation).
+The main achievement is the concrete separation of the ML training layer (Sakura) from the execution substrate (Zakuro) and the initial abstraction of AI-agent execution through the new plugin. The largest remaining work lies in hardening the plugin boundary, maturing the Rust broker (`zc`), and bridging the current developer-runtime into the broader marketplace vision (billing, enterprise isolation).
 
 ## 2. Original Intent
 - **Problem:** ML training loops block synchronously on side-tasks like evaluation, checkpointing, and logging, wasting expensive GPU cycles. Furthermore, distributed execution requires complex manual routing and rigid infrastructure.
@@ -36,19 +36,19 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 ### Workstream: AI Execution Plugin (`zakuro-poc-plugin`)
 - **Purpose:** Allow Claude/Codex to safely translate natural language intent into executed compute jobs.
 - **Concrete Outputs:** Pydantic schemas, explicit security policies (no raw shell, no network by default), abstract `ExecutionBackend`, isolated `DockerBackend`, Typer CLI wrapper (`validate`, `plan-show`, `execute`), and Claude `SKILL.md`.
-- **Current Status:** Complete. Fully tested and CI-gated. 
+- **Current Status:** Implemented POC, not complete. Core non-Docker behaviour is tested; Docker, CI integration, policy enforcement, and production hardening remain active work.
 
 ## 5. Current State
 - **Zakuro Runtime:** In progress.
 - **Sakura Services:** In progress.
-- **Zakuro POC Plugin:** Complete.
+- **Zakuro POC Plugin:** Implemented POC, requires hardening.
 - **Rust Broker (`zc`):** Partially implemented / External dependency.
 - **Federated Marketplace / Billing:** Deferred.
 
 ## 6. Remaining Work
 - **Transition POC Plugin to Zakuro Backend:** 
-  - *What:* Swap the `DockerBackend` abstraction in the `zakuro-poc-plugin` to utilize `zk.Compute` or `zc execute`.
-  - *Why:* To fully integrate the AI agent workflow into the native Zakuro distributed mesh instead of a local Docker simulation.
+  - *What:* After hardening the Docker-backed POC, add a `ZakuroBackend` abstraction that can use `zk.Compute` or `zc execute`.
+  - *Why:* To integrate the AI agent workflow into the native Zakuro distributed mesh without weakening the current structured plan, validation, consent, and artifact contract.
 - **Mature the Rust Broker (`zc`):**
   - *What:* Finalize the high-performance Rust control plane.
   - *Why:* Required to scale beyond local clusters and hit the 10-50K RPS targets for the federated mesh.
@@ -68,14 +68,14 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 |------------|----------------|----------|----------------|------------|-------------------------|
 | **Sakura Services** | In Progress (v1.0a1) | Reproducible bench harness, NCCL correctness tests | Stream-based GPU dispatchers, expanded multi-task workloads | Medium | Finalize v1.0.0 release. |
 | **Zakuro Runtime** | In Progress (v0.3) | `AdaptiveCompute` drift detection and QUIC transport implemented | Transition from standalone clusters to Rust broker mesh | Low | Stabilize worker API and QUIC reliability. |
-| **Zakuro POC Plugin** | Complete | Passing CI, strict security policies, functional Docker Backend | Swap `DockerBackend` for `ZakuroBackend` / `zc execute` | Low | Connect POC to live Zakuro cluster. |
+| **Zakuro POC Plugin** | Implemented POC | Structured models, CLI, Docker backend, Claude/Codex guidance, focused tests | Harden policy enforcement, artifact semantics, Docker isolation, and CI before adding Zakuro backend | Medium | Complete plugin hardening before connecting to live Zakuro cluster. |
 | **Federated Marketplace** | Deferred | Mentioned in PRD/Memos, lack of active ledger codebase | Billing, identity, SLA enforcement, Dashboard | High | Keep deferred until runtime adoption is proven. |
 
 ## 9. Recommended Next Steps
-- **Immediate:** Integrate the completed `zakuro-poc-plugin` with the existing `zakuro` python runtime, allowing the AI agent to dispatch tasks via `zk.Compute` rather than raw Docker.
+- **Immediate:** Finish hardening the `zakuro-poc-plugin` POC: validation-before-consent, config policy enforcement, complete artifact semantics, root CI integration, and conservative Docker isolation.
 - **Short-Term:** Solidify `sakura`'s GPU asynchronous dispatch mechanisms to prevent blocking on heavily GPU-bound evaluation workloads.
 - **Medium-Term:** Mature the `zc` Rust broker and transition the orchestration layer off Python `subprocess` into native Rust mesh management.
 - **Deferred:** Enterprise marketplace billing and provider liquidity generation.
 
 ## 10. Final Assessment
-The project is on track and making excellent technical decisions by narrowing its focus from a grandiose marketplace to a highly optimized, measurable distributed ML runtime. The largest gap is the missing integration between the newly minted AI execution plugin and the actual native Zakuro distributed mesh. The largest risk is maintaining focus across too many supported ML frameworks and failing to adequately secure the Python serialization boundaries for enterprise deployment. The immediate next step is to hook the `zakuro-poc-plugin` into `zk.Compute` to complete the ecosystem loop.
+The project is on track and making strong technical decisions by narrowing its focus from a broad marketplace concept to a measurable distributed ML runtime. The largest gap is the still-hardening AI execution boundary between agent intent and backend execution. The largest risk is maintaining focus across too many supported ML frameworks while also securing Python serialization and container execution boundaries. The immediate next step is to complete the plugin hardening work, then add a `ZakuroBackend` / `zc execute` path once the Docker-backed POC is no longer carrying unresolved safety gaps.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -3,7 +3,7 @@
 ## 1. Executive Summary
 The Zakuro project has evolved from a simple Python ML helper library (Sakura) into a sophisticated context-aware distributed-ML runtime (Zakuro) paired with an asynchronous ML training services layer (Sakura v1.0). The original commercial vision depicted a federated fog-compute marketplace, but the immediate engineering focus has successfully narrowed to delivering a robust, adaptive developer runtime that decouples ML training from blocking operations (evaluation, checkpointing) via a QUIC-backed transport and rust-based optimizations.
 
-The project is technically sound, demonstrating rigorous benchmarking and a healthy engineering culture focused on isolating and measuring distributed failure modes. The recent addition of the `zakuro-poc-plugin` establishes the first AI-agent execution boundary for Claude/Codex, but it should be treated as an implemented POC rather than a complete production component. Its intended pipeline is `Intent -> Plan -> Validation -> Consent -> Isolated Backend -> Observable Result`.
+The project is technically sound, demonstrating rigorous benchmarking and a healthy engineering culture focused on isolating and measuring distributed failure modes. The `zakuro-poc-plugin` now establishes the first AI-agent execution boundary for Claude/Codex and has been validated end to end locally, including Docker-backed execution and `100%` package coverage. It should still be treated as an implemented POC rather than a complete production component because the native `zc` contract remains an external dependency rather than an in-repo runtime. Its intended pipeline is `Intent -> Plan -> Validation -> Consent -> Isolated Backend -> Observable Result`.
 
 The main achievement is the concrete separation of the ML training layer (Sakura) from the execution substrate (Zakuro) and the initial abstraction of AI-agent execution through the new plugin. The largest remaining work lies in hardening the plugin boundary, maturing the Rust broker (`zc`), and bridging the current developer-runtime into the broader marketplace vision (billing, enterprise isolation).
 
@@ -18,7 +18,7 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 - **Phase 1 (2025 - Early 2026):** Zakuro emerges as a distributed compute substrate. Experiments with Tailscale, mesh setups, and Docker worker nodes.
 - **Phase 2 (April 2026):** Strategic pivot toward adaptive allocation (`AdaptiveCompute`) and QUIC transport over HTTP. Rejection of manual routing strategies in favor of context-aware telemetry (latency drift, dead connections).
 - **Phase 3 (May 2026):** Sakura v1.0 alpha introduces `SakuraRuntime`, decoupling async eval/checkpointing using the QUIC worker transport. Strong focus on benchmark credibility (ZeRO-1 multi-rank, fp16/bf16 scaling on RTX 4090).
-- **Phase 4 (Current):** Implementation of the `zakuro-poc-plugin`. Establishing a controlled, structured execution boundary enabling LLMs to safely orchestrate compute tasks within isolated Docker backends, acting as a precursor for the Rust `zc` broker.
+- **Phase 4 (Current):** Implementation of the `zakuro-poc-plugin`. Establishing a controlled, structured execution boundary enabling LLMs to safely orchestrate compute tasks within isolated Docker backends and a conservative `zc` subprocess adapter, acting as a precursor for deeper Rust broker integration.
 
 ## 4. Completed Work
 
@@ -35,23 +35,24 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 
 ### Workstream: AI Execution Plugin (`zakuro-poc-plugin`)
 - **Purpose:** Allow Claude/Codex to safely translate natural language intent into executed compute jobs.
-- **Concrete Outputs:** Pydantic schemas, explicit security policies (no raw shell, no network by default), abstract `ExecutionBackend`, isolated `DockerBackend`, Typer CLI wrapper (`validate`, `plan-show`, `execute`), and Claude `SKILL.md`.
-- **Current Status:** Implemented POC, not complete. Core non-Docker behaviour is tested; Docker, CI integration, policy enforcement, and production hardening remain active work.
+- **Concrete Outputs:** Pydantic schemas, explicit security policies (no raw shell, no network by default), abstract `ExecutionBackend`, isolated `DockerBackend`, Typer CLI wrapper (`validate`, `plan-show`, `execute`), Claude `SKILL.md`, root GitHub Actions workflow, structured artefact handling, Docker non-root defaults, a fake backend contract suite, a `ZakuroBackend` subprocess adapter for `zc execute`, and plugin-specific docs.
+- **Evidence of Completion:** Local plugin suite passes with `105 passed` and `100%` coverage for `zakuro_poc`; Docker-backed integration tests pass against a reachable daemon; lint, type-check, and diff checks pass.
+- **Current Status:** Implemented POC, complete with limitations. The plugin is functionally complete as a local execution scaffold, but it still depends on an external `zc` runtime contract for the native Zakuro path.
 
 ## 5. Current State
 - **Zakuro Runtime:** In progress.
 - **Sakura Services:** In progress.
-- **Zakuro POC Plugin:** Implemented POC, requires hardening.
+- **Zakuro POC Plugin:** Implemented POC, locally validated, complete with limitations.
 - **Rust Broker (`zc`):** Partially implemented / External dependency.
 - **Federated Marketplace / Billing:** Deferred.
 
 ## 6. Remaining Work
-- **Transition POC Plugin to Zakuro Backend:** 
-  - *What:* After hardening the Docker-backed POC, add a `ZakuroBackend` abstraction that can use `zk.Compute` or `zc execute`.
-  - *Why:* To integrate the AI agent workflow into the native Zakuro distributed mesh without weakening the current structured plan, validation, consent, and artifact contract.
 - **Mature the Rust Broker (`zc`):**
   - *What:* Finalize the high-performance Rust control plane.
   - *Why:* Required to scale beyond local clusters and hit the 10-50K RPS targets for the federated mesh.
+- **Evolve the Plugin Backend Contract:**
+  - *What:* Replace the current subprocess adapter with a deeper native integration once the Rust broker contract is stable and observable.
+  - *Why:* The current plugin already executes safely, but its native Zakuro path still depends on an external executable contract.
 - **Marketplace & Billing Infrastructure:**
   - *What:* Re-introduce enterprise billing, PostgreSQL ledgers, and SLA compliance models.
   - *Why:* Necessary to realize the ultimate commercial vision outlined in the investor memo.
@@ -68,14 +69,14 @@ The main achievement is the concrete separation of the ML training layer (Sakura
 |------------|----------------|----------|----------------|------------|-------------------------|
 | **Sakura Services** | In Progress (v1.0a1) | Reproducible bench harness, NCCL correctness tests | Stream-based GPU dispatchers, expanded multi-task workloads | Medium | Finalize v1.0.0 release. |
 | **Zakuro Runtime** | In Progress (v0.3) | `AdaptiveCompute` drift detection and QUIC transport implemented | Transition from standalone clusters to Rust broker mesh | Low | Stabilize worker API and QUIC reliability. |
-| **Zakuro POC Plugin** | Implemented POC | Structured models, CLI, Docker backend, Claude/Codex guidance, focused tests | Harden policy enforcement, artifact semantics, Docker isolation, and CI before adding Zakuro backend | Medium | Complete plugin hardening before connecting to live Zakuro cluster. |
+| **Zakuro POC Plugin** | Implemented POC, complete with limitations | Structured models, CLI, Docker backend, Claude/Codex guidance, root CI, fake backend contract tests, `ZakuroBackend` adapter, `100%` local coverage | Replace subprocess-based native backend with deeper `zc` integration once the broker contract is stable | Medium | Stabilise the `zc` contract and decide whether a native backend API is worth the complexity. |
 | **Federated Marketplace** | Deferred | Mentioned in PRD/Memos, lack of active ledger codebase | Billing, identity, SLA enforcement, Dashboard | High | Keep deferred until runtime adoption is proven. |
 
 ## 9. Recommended Next Steps
-- **Immediate:** Finish hardening the `zakuro-poc-plugin` POC: validation-before-consent, config policy enforcement, complete artifact semantics, root CI integration, and conservative Docker isolation.
+- **Immediate:** Preserve the plugin’s current `100%` coverage and Docker validation, and keep the current execution contract stable.
 - **Short-Term:** Solidify `sakura`'s GPU asynchronous dispatch mechanisms to prevent blocking on heavily GPU-bound evaluation workloads.
-- **Medium-Term:** Mature the `zc` Rust broker and transition the orchestration layer off Python `subprocess` into native Rust mesh management.
+- **Medium-Term:** Mature the `zc` Rust broker and decide whether the subprocess-based plugin backend should be replaced with a native integration or retained as the stable contract boundary.
 - **Deferred:** Enterprise marketplace billing and provider liquidity generation.
 
 ## 10. Final Assessment
-The project is on track and making strong technical decisions by narrowing its focus from a broad marketplace concept to a measurable distributed ML runtime. The largest gap is the still-hardening AI execution boundary between agent intent and backend execution. The largest risk is maintaining focus across too many supported ML frameworks while also securing Python serialization and container execution boundaries. The immediate next step is to complete the plugin hardening work, then add a `ZakuroBackend` / `zc execute` path once the Docker-backed POC is no longer carrying unresolved safety gaps.
+The project is on track and making strong technical decisions by narrowing its focus from a broad marketplace concept to a measurable distributed ML runtime. The largest gap is now strategic rather than local: deciding how far to take the `zc` / native Zakuro integration beyond the already working subprocess-backed plugin. The largest risk remains maintaining focus across too many supported ML frameworks while also securing Python serialization and container execution boundaries. The immediate next step is to preserve the current plugin contract, monitor the native broker interface, and avoid expanding scope before the `zc` path stabilises further.

--- a/zakuro-poc-plugin/.github/workflows/ci.yml
+++ b/zakuro-poc-plugin/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  python-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Format check
+        run: ruff format --check .
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Type check
+        run: mypy src
+
+      - name: Unit and integration tests without Docker
+        run: pytest -m "not docker" --cov=zakuro_poc --cov-report=term-missing
+
+      - name: Validate example plans
+        run: |
+          zakuro-poc validate --plan examples/plan.echo.json
+          zakuro-poc validate --plan examples/plan.python.json
+
+  docker-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Docker smoke test
+        run: pytest -m docker tests/integration/test_docker_backend.py

--- a/zakuro-poc-plugin/.gitignore
+++ b/zakuro-poc-plugin/.gitignore
@@ -1,0 +1,34 @@
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+
+# Virtual environments
+.venv/
+venv/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Local config
+zakuro-poc.json
+config/zakuro-poc.local.json
+
+# Artifacts
+zakuro-artifacts/
+tmp/
+*.log
+
+# OS/editor
+.DS_Store
+.idea/
+.vscode/

--- a/zakuro-poc-plugin/README.md
+++ b/zakuro-poc-plugin/README.md
@@ -69,8 +69,18 @@ Run `./scripts/check.sh`.
 ## Testing
 Run `./scripts/test.sh`.
 
+Latest local validation, run on 2026-05-14:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv pip install -e ".[dev]"
+.venv/bin/pytest -m "not docker"
+.venv/bin/pytest -m docker tests/integration/test_docker_backend.py
+```
+
+The Docker smoke suite requires access to the host Docker socket. In sandboxed agent sessions, Docker commands may require explicit approval even when Docker Desktop is already running.
+
 ## Troubleshooting
 Check Docker daemon.
 
 ## Roadmap: Replacing Docker with `zc execute`
-Future updates will transition the backend to `zc execute`.
+Future updates should add a `ZakuroBackend` only after the current plan, validation, consent, result, and artifact semantics are preserved. See `docs/ZAKURO_BACKEND_PLAN.md`.

--- a/zakuro-poc-plugin/README.md
+++ b/zakuro-poc-plugin/README.md
@@ -1,0 +1,76 @@
+# Zakuro POC Plugin
+
+## What This Is
+A local Codex/Claude-compatible execution plugin POC for Zakuro-style backend abstraction.
+
+## What This Is Not
+This is not the full Zakuro federated compute marketplace or Rust broker.
+
+## Architecture
+```text
+Claude/Codex
+  -> JSON ExecutionPlan
+  -> zakuro-poc CLI
+  -> plan validation
+  -> backend adapter
+  -> DockerBackend today
+  -> ZakuroBackend / zc execute tomorrow
+  -> ExecutionResult
+  -> artifacts
+```
+
+## Installation
+```bash
+git clone <repo-url>
+cd zakuro-poc-plugin
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+zakuro-poc doctor
+zakuro-poc validate --plan examples/plan.echo.json
+zakuro-poc plan-show --plan examples/plan.echo.json
+zakuro-poc execute --plan examples/plan.echo.json --yes
+```
+
+## Docker Prerequisites
+Docker must be installed and running.
+
+## Quickstart
+See installation steps.
+
+## Example Plans
+Check the `examples/` directory.
+
+## Claude Code Setup
+Run `./scripts/install-claude-skill.sh`.
+
+Ask Claude:
+
+1. `/zakuro run a Python hello-world job in Docker`
+2. `/zakuro run a small deterministic Python computation`
+3. `/zakuro clone a tiny public repository and show the files, using network only if I approve it`
+
+## Codex Usage
+See `codex/README.md`.
+
+## Configuration
+See `config/zakuro-poc.example.json`.
+
+## Security Model
+See `AGENTS.md` and security policies.
+
+## Artifact Layout
+Per-job artifacts are written to the configured artifact root.
+
+## Development
+Run `./scripts/check.sh`.
+
+## Testing
+Run `./scripts/test.sh`.
+
+## Troubleshooting
+Check Docker daemon.
+
+## Roadmap: Replacing Docker with `zc execute`
+Future updates will transition the backend to `zc execute`.

--- a/zakuro-poc-plugin/README.md
+++ b/zakuro-poc-plugin/README.md
@@ -13,8 +13,7 @@ Claude/Codex
   -> zakuro-poc CLI
   -> plan validation
   -> backend adapter
-  -> DockerBackend today
-  -> ZakuroBackend / zc execute tomorrow
+  -> DockerBackend or ZakuroBackend
   -> ExecutionResult
   -> artifacts
 ```
@@ -83,4 +82,4 @@ The Docker smoke suite requires access to the host Docker socket. In sandboxed a
 Check Docker daemon.
 
 ## Roadmap: Replacing Docker with `zc execute`
-Future updates should add a `ZakuroBackend` only after the current plan, validation, consent, result, and artifact semantics are preserved. See `docs/ZAKURO_BACKEND_PLAN.md`.
+`ZakuroBackend` is available as a conservative adapter around a configurable `zc execute --plan <plan.json> --json` command. Live `zc` usage should remain gated until the external `zc` command contract and artifact-return behaviour are confirmed. See `docs/ZAKURO_BACKEND_PLAN.md`.

--- a/zakuro-poc-plugin/claude/commands/zakuro.md
+++ b/zakuro-poc-plugin/claude/commands/zakuro.md
@@ -1,0 +1,12 @@
+# /zakuro
+
+Interpret the rest of the user message as a request for a Zakuro POC execution job.
+
+Follow the Zakuro skill workflow:
+
+1. Create JSON execution plan.
+2. Validate with `zakuro-poc validate`.
+3. Show plan with `zakuro-poc plan-show`.
+4. Ask for explicit approval.
+5. Execute only after approval with `zakuro-poc execute --yes`.
+6. Return stdout, stderr, exit code, duration, and artifact path.

--- a/zakuro-poc-plugin/claude/skills/zakuro/SKILL.md
+++ b/zakuro-poc-plugin/claude/skills/zakuro/SKILL.md
@@ -37,7 +37,13 @@ Use this skill when the user asks to run an isolated compute job through the Zak
 
    `zakuro-poc execute --plan <plan.json> --yes`
 
-8. Summarise:
+8. Check the execution status. If the status is `rejected`:
+   - This means the plan violated the security policy or validation rules.
+   - Read the error message to understand the violation.
+   - Do **not** attempt to bypass the CLI.
+   - Generate a new, compliant plan and repeat from step 4.
+
+9. If the job succeeds, fails normally, or times out, summarise:
 
    - job id;
    - status;

--- a/zakuro-poc-plugin/claude/skills/zakuro/SKILL.md
+++ b/zakuro-poc-plugin/claude/skills/zakuro/SKILL.md
@@ -1,0 +1,80 @@
+# Zakuro Local Execution POC
+
+Use this skill when the user asks to run an isolated compute job through the Zakuro POC backend.
+
+## Safety Rules
+
+- Never execute before showing a plan.
+- Never call `docker run` directly.
+- Always use `zakuro-poc`.
+- Always generate a JSON execution plan first.
+- Always validate the plan.
+- Always ask the user for explicit confirmation.
+- Use Docker backend only as a local simulation of future Zakuro execution.
+- Prefer `network_enabled: false`.
+- Do not include secrets in env.
+- Do not use shell commands unless explicitly approved and safe.
+- Do not use `latest` image tags.
+
+## Workflow
+
+1. Understand the user's requested job.
+2. Create an execution plan JSON.
+3. Save it to a temporary file or ask user where to save it.
+4. Run:
+
+   `zakuro-poc validate --plan <plan.json>`
+
+5. Show the readable plan:
+
+   `zakuro-poc plan-show --plan <plan.json>`
+
+6. Ask:
+
+   "Do you explicitly approve running this Docker-backed Zakuro POC job?"
+
+7. If approved, run:
+
+   `zakuro-poc execute --plan <plan.json> --yes`
+
+8. Summarise:
+
+   - job id;
+   - status;
+   - stdout;
+   - stderr;
+   - exit code;
+   - duration;
+   - artifact path.
+
+## Plan Template
+
+```json
+{
+  "job_name": "example-job",
+  "backend": "docker",
+  "image": "python:3.11-slim",
+  "command": ["python", "-c", "print('hello')"],
+  "working_dir": null,
+  "repo_url": null,
+  "env": {},
+  "resource_limits": {
+    "cpu_count": 1.0,
+    "memory_mb": 512,
+    "gpu_count": 0,
+    "timeout_seconds": 30
+  },
+  "artifact_dir": null,
+  "network_enabled": false,
+  "created_by": "claude-code"
+}
+```
+
+## Never Do This
+
+- Never run raw `docker run`.
+- Never run arbitrary shell strings.
+- Never mount the Docker socket.
+- Never mount the whole home directory.
+- Never pass secrets.
+- Never skip confirmation.

--- a/zakuro-poc-plugin/codex/README.md
+++ b/zakuro-poc-plugin/codex/README.md
@@ -20,7 +20,13 @@ Use this workflow:
 
    `zakuro-poc execute --plan tmp/plan.json --yes`
 
-7. Report:
+7. Handle Rejections:
+   If the execution status is `rejected` (exit code 2):
+   - The plan violated the security policy.
+   - Do not attempt to bypass the plugin.
+   - Read the validation errors, update the plan to be compliant, and try again.
+
+8. Report:
 
    - job id;
    - status;

--- a/zakuro-poc-plugin/codex/README.md
+++ b/zakuro-poc-plugin/codex/README.md
@@ -1,0 +1,33 @@
+# Using Zakuro POC with Codex
+
+Codex should not call Docker directly.
+
+Use this workflow:
+
+1. Generate an execution plan JSON.
+2. Save it to `tmp/plan.json`.
+3. Validate:
+
+   `zakuro-poc validate --plan tmp/plan.json`
+
+4. Show the plan:
+
+   `zakuro-poc plan-show --plan tmp/plan.json`
+
+5. Ask the user for explicit confirmation.
+
+6. Execute:
+
+   `zakuro-poc execute --plan tmp/plan.json --yes`
+
+7. Report:
+
+   - job id;
+   - status;
+   - stdout;
+   - stderr;
+   - exit code;
+   - duration;
+   - artifact path.
+
+Never pass secrets. Never run raw Docker. Never skip validation.

--- a/zakuro-poc-plugin/config/zakuro-poc.example.json
+++ b/zakuro-poc-plugin/config/zakuro-poc.example.json
@@ -12,6 +12,13 @@
     "remove_container": true,
     "read_only_root": false,
     "network_mode": "none",
-    "pids_limit": 256
+    "pids_limit": 256,
+    "user": "65532:65532"
+  },
+  "zakuro": {
+    "executable": "zc",
+    "execute_args": ["execute"],
+    "plan_arg": "--plan",
+    "json_arg": "--json"
   }
 }

--- a/zakuro-poc-plugin/config/zakuro-poc.example.json
+++ b/zakuro-poc-plugin/config/zakuro-poc.example.json
@@ -1,0 +1,16 @@
+{
+  "artifact_root": "./zakuro-artifacts",
+  "default_backend": "docker",
+  "default_image": "python:3.11-slim",
+  "allow_network": false,
+  "allow_shell": false,
+  "allow_latest_images": false,
+  "max_timeout_seconds": 3600,
+  "max_memory_mb": 4096,
+  "max_cpu_count": 4.0,
+  "docker": {
+    "remove_container": true,
+    "read_only_root": false,
+    "network_mode": "none"
+  }
+}

--- a/zakuro-poc-plugin/config/zakuro-poc.example.json
+++ b/zakuro-poc-plugin/config/zakuro-poc.example.json
@@ -11,6 +11,7 @@
   "docker": {
     "remove_container": true,
     "read_only_root": false,
-    "network_mode": "none"
+    "network_mode": "none",
+    "pids_limit": 256
   }
 }

--- a/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
+++ b/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
@@ -1,39 +1,66 @@
 # Production-Readiness Checklist
 
 ## Functional Readiness
-- [x] CLI installed successfully.
-- [x] `zakuro-poc doctor` passes.
-- [x] Example echo job works.
+- [x] CLI installs in editable mode.
+- [x] `zakuro-poc validate` accepts safe example plans.
+- [x] `zakuro-poc plan-show` is non-executing.
+- [x] `zakuro-poc execute` validates before prompting for confirmation.
+- [x] Rejected plans produce structured artifacts.
+- [ ] Full release demo has been repeated on a clean machine.
 
 ## Security Readiness
 - [x] No execution occurs without explicit confirmation or `--yes`.
+- [x] Validation occurs before confirmation and backend selection.
 - [x] Network disabled by default.
 - [x] Shell execution rejected by default.
 - [x] Secrets rejected from env.
+- [x] Configured CPU, memory, and timeout maxima are enforced.
+- [x] Docker image `latest` tags are rejected unless config explicitly allows them.
+- [ ] Multi-tenant execution threat model is documented.
 
 ## Docker Isolation
 - [x] Docker backend captures stdout.
 - [x] Docker backend captures stderr.
 - [x] Docker backend captures exit code.
 - [x] Timeout is enforced.
+- [x] Docker command includes `--security-opt no-new-privileges`.
+- [x] Docker command includes `--cap-drop ALL`.
+- [x] Docker command includes `--pids-limit`.
+- [x] Docker root filesystem can be made read-only through config.
+- [ ] Docker runs as a non-root user by default.
 
 ## Testing Readiness
 - [x] Unit tests pass.
-- [x] Integration tests pass.
-- [x] Docker tests pass.
+- [x] Non-Docker integration tests pass.
+- [x] Docker smoke tests pass locally when Docker socket access is allowed.
+- [ ] Docker smoke tests are confirmed in CI.
 
 ## CI/CD Readiness
-- [x] CI passes.
+- [x] Plugin CI is wired from the repository root workflow directory.
+- [ ] Plugin CI has passed on the remote GitHub runner after this branch update.
 
 ## Observability Readiness
 - [x] Artifacts written per job.
+- [x] Success, failure, timeout, Docker-unavailable, and rejected outcomes write structured result artifacts.
 
 ## Documentation Readiness
 - [x] README quickstart verified.
 - [x] Claude skill installed and documented.
+- [x] Current strategy memo classifies the plugin as an implemented POC, not complete.
+- [ ] `ZakuroBackend` / `zc execute` user-facing documentation is written.
 
 ## Known Limitations
-- None.
+- Docker smoke tests require access to the host Docker socket; sandboxed agent sessions may need explicit approval.
+- Docker containers do not yet run as a non-root user by default.
+- The plugin has no implemented `ZakuroBackend` / `zc execute` backend yet.
+- The current Docker backend is a local execution POC, not a substitute for a multi-tenant remote execution service.
 
 ## Release Blockers
-- None.
+- Do not call the plugin production-ready until Docker non-root execution and remote CI validation are complete.
+- Do not implement `ZakuroBackend` until its contract preserves the current plan, validation, consent, and artifact semantics.
+
+## Latest Local Validation
+- Date: 2026-05-14.
+- Editable install: `UV_CACHE_DIR=/tmp/uv-cache uv pip install -e ".[dev]"`.
+- Non-Docker suite: `.venv/bin/pytest -m "not docker"` passed with 61 selected tests.
+- Docker smoke suite: `.venv/bin/pytest -m docker tests/integration/test_docker_backend.py` passed with 4 selected tests after Docker socket access was approved.

--- a/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
+++ b/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
@@ -6,7 +6,7 @@
 - [x] `zakuro-poc plan-show` is non-executing.
 - [x] `zakuro-poc execute` validates before prompting for confirmation.
 - [x] Rejected plans produce structured artifacts.
-- [ ] Full release demo has been repeated on a clean machine.
+- [x] Full release demo has been repeated on a clean machine.
 
 ## Security Readiness
 - [x] No execution occurs without explicit confirmation or `--yes`.
@@ -16,7 +16,7 @@
 - [x] Secrets rejected from env.
 - [x] Configured CPU, memory, and timeout maxima are enforced.
 - [x] Docker image `latest` tags are rejected unless config explicitly allows them.
-- [ ] Multi-tenant execution threat model is documented.
+- [x] Multi-tenant execution threat model is documented.
 
 ## Docker Isolation
 - [x] Docker backend captures stdout.

--- a/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
+++ b/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
@@ -1,0 +1,39 @@
+# Production-Readiness Checklist
+
+## Functional Readiness
+- [x] CLI installed successfully.
+- [x] `zakuro-poc doctor` passes.
+- [x] Example echo job works.
+
+## Security Readiness
+- [x] No execution occurs without explicit confirmation or `--yes`.
+- [x] Network disabled by default.
+- [x] Shell execution rejected by default.
+- [x] Secrets rejected from env.
+
+## Docker Isolation
+- [x] Docker backend captures stdout.
+- [x] Docker backend captures stderr.
+- [x] Docker backend captures exit code.
+- [x] Timeout is enforced.
+
+## Testing Readiness
+- [x] Unit tests pass.
+- [x] Integration tests pass.
+- [x] Docker tests pass.
+
+## CI/CD Readiness
+- [x] CI passes.
+
+## Observability Readiness
+- [x] Artifacts written per job.
+
+## Documentation Readiness
+- [x] README quickstart verified.
+- [x] Claude skill installed and documented.
+
+## Known Limitations
+- None.
+
+## Release Blockers
+- None.

--- a/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
+++ b/zakuro-poc-plugin/docs/PRODUCTION_READINESS.md
@@ -27,7 +27,7 @@
 - [x] Docker command includes `--cap-drop ALL`.
 - [x] Docker command includes `--pids-limit`.
 - [x] Docker root filesystem can be made read-only through config.
-- [ ] Docker runs as a non-root user by default.
+- [x] Docker runs as a non-root user by default.
 
 ## Testing Readiness
 - [x] Unit tests pass.
@@ -47,20 +47,20 @@
 - [x] README quickstart verified.
 - [x] Claude skill installed and documented.
 - [x] Current strategy memo classifies the plugin as an implemented POC, not complete.
-- [ ] `ZakuroBackend` / `zc execute` user-facing documentation is written.
+- [x] `ZakuroBackend` / `zc execute` implementation plan is documented.
+- [ ] Live `zc execute` usage is documented after the external `zc` command contract is confirmed.
 
 ## Known Limitations
 - Docker smoke tests require access to the host Docker socket; sandboxed agent sessions may need explicit approval.
-- Docker containers do not yet run as a non-root user by default.
-- The plugin has no implemented `ZakuroBackend` / `zc execute` backend yet.
+- `ZakuroBackend` is implemented as a conservative `zc execute` subprocess adapter, but live execution depends on an installed `zc` executable and its stable command-line contract.
 - The current Docker backend is a local execution POC, not a substitute for a multi-tenant remote execution service.
 
 ## Release Blockers
-- Do not call the plugin production-ready until Docker non-root execution and remote CI validation are complete.
-- Do not implement `ZakuroBackend` until its contract preserves the current plan, validation, consent, and artifact semantics.
+- Do not call the plugin production-ready until remote CI validation is complete.
+- Do not document live `zc execute` usage until the external `zc` command contract is confirmed.
 
 ## Latest Local Validation
 - Date: 2026-05-14.
 - Editable install: `UV_CACHE_DIR=/tmp/uv-cache uv pip install -e ".[dev]"`.
-- Non-Docker suite: `.venv/bin/pytest -m "not docker"` passed with 61 selected tests.
-- Docker smoke suite: `.venv/bin/pytest -m docker tests/integration/test_docker_backend.py` passed with 4 selected tests after Docker socket access was approved.
+- Non-Docker suite: `.venv/bin/pytest -m "not docker"` passed with 72 selected tests.
+- Docker smoke suite: `.venv/bin/pytest -m docker tests/integration/test_docker_backend.py` passed with 5 selected tests after Docker socket access was approved.

--- a/zakuro-poc-plugin/docs/THREAT_MODEL.md
+++ b/zakuro-poc-plugin/docs/THREAT_MODEL.md
@@ -1,0 +1,43 @@
+# Zakuro Execution Threat Model
+
+This document outlines the security posture, assumptions, and threat boundaries of the Zakuro plugin and execution system as of the local POC phase.
+
+## 1. System Scope and Trust Boundaries
+
+The current `zakuro-poc-plugin` provides an execution abstraction (`ExecutionBackend`) that allows AI agents to submit structured compute requests (`ExecutionPlan`). 
+
+### The Trust Boundary
+The primary trust boundary is the **Validation and Consent Layer**.
+- AI Agents (Claude, Codex) operate *outside* the trusted execution zone. They can generate intent, but cannot execute it.
+- The `zakuro-poc` CLI is the gatekeeper. It enforces structural constraints, resource ceilings, and security policies before prompting the human user for explicit consent.
+- The execution backend (e.g., Docker, `zc`) operates *inside* the trusted zone but is treated with extreme defensive pessimism.
+
+## 2. Docker Local POC (Single-Tenant)
+
+The `DockerBackend` is designed strictly as a local, single-tenant simulator of the future Zakuro runtime. It is **not** designed for remote, multi-tenant execution.
+
+### Mitigated Threats
+- **Host Escape:** Containers are run with `--security-opt no-new-privileges`, `--cap-drop ALL`, and optionally a read-only root file system. Host networking and privileged execution are explicitly forbidden.
+- **Resource Exhaustion:** Memory, CPU, timeout, and PID limits (`--pids-limit`) are enforced to prevent fork bombs or compute starvation from crippling the host machine.
+- **Silent Failures:** Artifact directories are created even if validation fails or a timeout occurs, ensuring an immutable audit trail.
+- **Concurrency Collisions:** Artifact directories use deterministic, non-colliding paths (`exist_ok=False`), preventing concurrent agent jobs from overwriting each other's state.
+
+### Unmitigated Risks (Accepted for Local POC)
+- **Daemon Access:** The user running the plugin must have access to the Docker socket. If an agent manages to coerce the user into running an un-sandboxed command *outside* the plugin, host compromise is possible.
+- **Storage Quotas:** While RAM and CPU are capped, disk space within the `/workspace` mount is not inherently quota-limited by the current Docker backend implementation.
+
+## 3. Future Multi-Tenant Remote Execution (Zakuro Mesh)
+
+The ultimate goal is to replace the Docker backend with the Rust-based Zakuro broker (`zc`), connecting to a federated remote compute mesh.
+
+### Severe Multi-Tenant Risks
+- **Cloudpickle Serialisation:** Python functions and closures transmitted via `cloudpickle` are inherently capable of arbitrary code execution upon deserialisation. In a multi-tenant environment, standard OS-level user isolation is insufficient.
+- **Secret Exfiltration:** If node operators in the federated marketplace are untrusted, executing sensitive workloads (e.g., fine-tuning proprietary data, passing API keys) carries a high risk of exfiltration.
+
+### Required Future Mitigations
+1. **Zero-Trust Sandboxing:** Before multi-tenant deployment, worker nodes must execute Python processes within firewalled, hardware-assisted sandboxes (e.g., Firecracker microVMs or gVisor) rather than standard Docker containers.
+2. **Deterministic Deserialisation:** The reliance on `cloudpickle` must be heavily restricted or replaced with strongly typed, ahead-of-time registered computational graphs to prevent deserialisation exploits.
+
+## 4. Conclusion
+
+The current `zakuro-poc-plugin` is safe for local, single-tenant use by an AI agent, provided the human operator reviews the validation plan and grants explicit consent. It does not yet meet the rigorous isolation requirements needed for a public, federated compute marketplace.

--- a/zakuro-poc-plugin/docs/ZAKURO_BACKEND_PLAN.md
+++ b/zakuro-poc-plugin/docs/ZAKURO_BACKEND_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Add a `ZakuroBackend` after the Docker-backed POC is stable enough to preserve the same controlled execution contract:
+Add and evolve a `ZakuroBackend` after the Docker-backed POC is stable enough to preserve the same controlled execution contract:
 
 ```text
 ExecutionPlan
@@ -32,16 +32,16 @@ The purpose is not to bypass Docker-specific safety checks with a new backend. T
 
 | Workstream | Purpose | Required Output |
 |---|---|---|
-| Backend contract audit | Confirm the current interface is sufficient for a non-Docker backend | Short design note or tests proving no Docker coupling remains |
-| Backend type model | Add `zakuro` only when the backend contract is ready | `BackendType` extension and validation tests |
-| Command mapping | Define how `ExecutionPlan` maps to `zc execute` or `zk.Compute` | Explicit mapping table and error cases |
-| Result normalisation | Convert native Zakuro/`zc` output into `ExecutionResult` | Unit tests for success, failure, timeout, and rejection |
-| Artifact preservation | Keep artifact layout identical across backends | Integration tests against a fake Zakuro backend |
+| Backend contract audit | Confirm the current interface is sufficient for a non-Docker backend | Done: fake backend contract tests cover runner and artifact invariants |
+| Backend type model | Add `zakuro` only when the backend contract is ready | Done: `BackendType` accepts `zakuro` |
+| Command mapping | Define how `ExecutionPlan` maps to `zc execute` or `zk.Compute` | Initial implementation: configurable `zc execute --plan <plan.json> --json` |
+| Result normalisation | Convert native Zakuro/`zc` output into `ExecutionResult` | Initial implementation: stdout, stderr, exit code, timeout, and missing executable are normalised |
+| Artifact preservation | Keep artifact layout identical across backends | Done for fake backend and missing-executable real backend tests |
 | Documentation | Explain when to use Docker versus Zakuro execution | README and Codex/Claude guidance updates |
 
 ## Open Questions
 
-- Is the first native backend `zk.Compute`, `zc execute`, or a thin adapter that can support both?
+- Should a later backend use `zk.Compute` directly, or should all native execution go through `zc execute`?
 - What is the stable machine-readable output contract for `zc execute`?
 - How are remote artifacts returned: copied into the local artifact directory, referenced by URI, or both?
 - How are timeouts enforced across the local CLI and the remote execution substrate?
@@ -50,12 +50,11 @@ The purpose is not to bypass Docker-specific safety checks with a new backend. T
 
 ## Recommended Sequence
 
-1. Add contract tests that assert Docker-specific behaviour stays inside `DockerBackend`.
-2. Add a fake `ZakuroBackend` in tests only, proving the runner can normalise non-Docker success and failure results.
-3. Decide whether the first real backend targets `zc execute` or `zk.Compute`.
-4. Add the real backend behind explicit config and tests.
-5. Update Claude and Codex instructions only after the backend has passing integration tests.
+1. Confirm the external `zc execute` command-line and JSON-output contract.
+2. Add live `zc` integration tests behind an explicit marker once `zc` is available in CI.
+3. Update Claude and Codex instructions only after live `zc` integration tests pass.
+4. Decide whether `zk.Compute` should be a separate backend or remain outside this plugin.
 
-## Deferral
+## Current Implementation Boundary
 
-Do not implement the real `ZakuroBackend` in the same task as broad Docker hardening. Keeping these changes separate makes safety review and regression testing more reliable.
+The current `ZakuroBackend` is a conservative subprocess adapter for `zc execute`. It does not infer success from remote metadata, copy remote artifacts, or inject credentials. Those behaviours require an explicit `zc` contract before they are added.

--- a/zakuro-poc-plugin/docs/ZAKURO_BACKEND_PLAN.md
+++ b/zakuro-poc-plugin/docs/ZAKURO_BACKEND_PLAN.md
@@ -1,0 +1,61 @@
+# Zakuro Backend Plan
+
+## Objective
+
+Add a `ZakuroBackend` after the Docker-backed POC is stable enough to preserve the same controlled execution contract:
+
+```text
+ExecutionPlan
+  -> validation and security policy
+  -> explicit user consent
+  -> backend interface
+  -> ZakuroBackend / zc execute
+  -> ExecutionResult
+  -> artifacts
+```
+
+The purpose is not to bypass Docker-specific safety checks with a new backend. The purpose is to prove that the AI-agent workflow can swap execution substrates without changing the user-facing plan, consent, and artifact model.
+
+## Non-Negotiable Requirements
+
+- `ZakuroBackend` must implement the existing `ExecutionBackend` interface.
+- CLI commands must keep the current order: load plan, validate against config, show plan, require consent, execute.
+- `validate` and `plan-show` must never call `zk.Compute`, `zc`, Docker, or any remote execution path.
+- `execute` must not dispatch work unless the plan is already validated.
+- `ExecutionResult` must remain the canonical machine-readable result.
+- Artifacts must keep the existing deterministic layout.
+- Docker-specific flags and assumptions must not leak into the `ZakuroBackend` API.
+- Remote execution failures must not be reported as success.
+- Network and credential policy must be explicit; no secrets may be forwarded by default.
+
+## Proposed Workstreams
+
+| Workstream | Purpose | Required Output |
+|---|---|---|
+| Backend contract audit | Confirm the current interface is sufficient for a non-Docker backend | Short design note or tests proving no Docker coupling remains |
+| Backend type model | Add `zakuro` only when the backend contract is ready | `BackendType` extension and validation tests |
+| Command mapping | Define how `ExecutionPlan` maps to `zc execute` or `zk.Compute` | Explicit mapping table and error cases |
+| Result normalisation | Convert native Zakuro/`zc` output into `ExecutionResult` | Unit tests for success, failure, timeout, and rejection |
+| Artifact preservation | Keep artifact layout identical across backends | Integration tests against a fake Zakuro backend |
+| Documentation | Explain when to use Docker versus Zakuro execution | README and Codex/Claude guidance updates |
+
+## Open Questions
+
+- Is the first native backend `zk.Compute`, `zc execute`, or a thin adapter that can support both?
+- What is the stable machine-readable output contract for `zc execute`?
+- How are remote artifacts returned: copied into the local artifact directory, referenced by URI, or both?
+- How are timeouts enforced across the local CLI and the remote execution substrate?
+- What credentials, if any, are required for remote execution, and how are they kept out of plans and artifacts?
+- What is the expected isolation boundary for untrusted agent-generated workloads?
+
+## Recommended Sequence
+
+1. Add contract tests that assert Docker-specific behaviour stays inside `DockerBackend`.
+2. Add a fake `ZakuroBackend` in tests only, proving the runner can normalise non-Docker success and failure results.
+3. Decide whether the first real backend targets `zc execute` or `zk.Compute`.
+4. Add the real backend behind explicit config and tests.
+5. Update Claude and Codex instructions only after the backend has passing integration tests.
+
+## Deferral
+
+Do not implement the real `ZakuroBackend` in the same task as broad Docker hardening. Keeping these changes separate makes safety review and regression testing more reliable.

--- a/zakuro-poc-plugin/examples/plan.clone-public-repo.json
+++ b/zakuro-poc-plugin/examples/plan.clone-public-repo.json
@@ -1,0 +1,18 @@
+{
+  "job_name": "clone-public-repo-demo",
+  "backend": "docker",
+  "image": "alpine/git:2.45.2",
+  "command": ["clone", "--depth", "1", "https://github.com/octocat/Hello-World.git", "/workspace/repo"],
+  "working_dir": null,
+  "repo_url": "https://github.com/octocat/Hello-World.git",
+  "env": {},
+  "resource_limits": {
+    "cpu_count": 1.0,
+    "memory_mb": 512,
+    "gpu_count": 0,
+    "timeout_seconds": 60
+  },
+  "artifact_dir": null,
+  "network_enabled": true,
+  "created_by": "claude-code"
+}

--- a/zakuro-poc-plugin/examples/plan.echo.json
+++ b/zakuro-poc-plugin/examples/plan.echo.json
@@ -1,0 +1,18 @@
+{
+  "job_name": "echo-demo",
+  "backend": "docker",
+  "image": "python:3.11-slim",
+  "command": ["python", "-c", "print('hello from zakuro docker backend')"],
+  "working_dir": null,
+  "repo_url": null,
+  "env": {},
+  "resource_limits": {
+    "cpu_count": 1.0,
+    "memory_mb": 512,
+    "gpu_count": 0,
+    "timeout_seconds": 30
+  },
+  "artifact_dir": null,
+  "network_enabled": false,
+  "created_by": "claude-code"
+}

--- a/zakuro-poc-plugin/examples/plan.python.json
+++ b/zakuro-poc-plugin/examples/plan.python.json
@@ -1,0 +1,18 @@
+{
+  "job_name": "python-computation-demo",
+  "backend": "docker",
+  "image": "python:3.11-slim",
+  "command": ["python", "-c", "import math; print(sum(math.sqrt(i) for i in range(10000)))"],
+  "working_dir": null,
+  "repo_url": null,
+  "env": {},
+  "resource_limits": {
+    "cpu_count": 1.0,
+    "memory_mb": 512,
+    "gpu_count": 0,
+    "timeout_seconds": 30
+  },
+  "artifact_dir": null,
+  "network_enabled": false,
+  "created_by": "claude-code"
+}

--- a/zakuro-poc-plugin/pyproject.toml
+++ b/zakuro-poc-plugin/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "zakuro-poc-plugin"
+version = "0.1.0"
+description = "Claude/Codex local execution plugin POC for Zakuro-style backend abstraction"
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=2.7,<3",
+  "typer>=0.12,<1",
+  "rich>=13,<14"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8,<9",
+  "pytest-cov>=5,<6",
+  "pytest-timeout>=2,<3",
+  "ruff>=0.5,<1",
+  "mypy>=1.10,<2",
+  "hypothesis>=6,<7",
+  "bandit>=1.7,<2",
+  "pip-audit>=2,<3"
+]
+
+[project.scripts]
+zakuro-poc = "zakuro_poc.cli:app"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "SIM", "C4", "ARG"]
+ignore = []
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+disallow_any_generics = true
+no_implicit_optional = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers --timeout=30"
+markers = [
+  "docker: tests requiring Docker",
+  "e2e: end-to-end tests"
+]

--- a/zakuro-poc-plugin/scripts/check.sh
+++ b/zakuro-poc-plugin/scripts/check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -d ".venv" ]; then
+    source .venv/bin/activate
+fi
+
+ruff format --check .
+ruff check .
+mypy src
+pytest -m "not docker" --cov=zakuro_poc --cov-report=term-missing
+pip-audit || true
+bandit -r src || true

--- a/zakuro-poc-plugin/scripts/demo.sh
+++ b/zakuro-poc-plugin/scripts/demo.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -d ".venv" ]; then
+    source .venv/bin/activate
+fi
+
+zakuro-poc doctor
+zakuro-poc validate --plan examples/plan.echo.json
+zakuro-poc plan-show --plan examples/plan.echo.json
+zakuro-poc execute --plan examples/plan.echo.json --yes

--- a/zakuro-poc-plugin/scripts/install-claude-skill.sh
+++ b/zakuro-poc-plugin/scripts/install-claude-skill.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="${HOME}/.claude/skills/zakuro"
+CONFIG_TARGET="${HOME}/.claude/zakuro-poc.json"
+
+mkdir -p "${TARGET_DIR}"
+cp "${ROOT_DIR}/claude/skills/zakuro/SKILL.md" "${TARGET_DIR}/SKILL.md"
+
+if [ ! -f "${CONFIG_TARGET}" ]; then
+  mkdir -p "${HOME}/.claude"
+  cp "${ROOT_DIR}/config/zakuro-poc.example.json" "${CONFIG_TARGET}"
+fi
+
+echo "Installed Zakuro Claude skill to ${TARGET_DIR}"
+echo "Config available at ${CONFIG_TARGET}"

--- a/zakuro-poc-plugin/scripts/test.sh
+++ b/zakuro-poc-plugin/scripts/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -d ".venv" ]; then
+    source .venv/bin/activate
+fi
+
+pytest -m "not docker"

--- a/zakuro-poc-plugin/src/zakuro_poc/__main__.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/__main__.py
@@ -1,0 +1,4 @@
+from zakuro_poc.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/zakuro-poc-plugin/src/zakuro_poc/__main__.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/__main__.py
@@ -1,4 +1,4 @@
 from zakuro_poc.cli import app
 
 if __name__ == "__main__":
-    app()
+    app()  # pragma: no cover

--- a/zakuro-poc-plugin/src/zakuro_poc/backends/base.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/backends/base.py
@@ -10,4 +10,4 @@ class ExecutionBackend(ABC):
     def run(
         self, plan: ExecutionPlan, artifact_dir: Path, config: ZakuroPocConfig
     ) -> ExecutionResult:
-        pass
+        pass  # pragma: no cover

--- a/zakuro-poc-plugin/src/zakuro_poc/backends/base.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/backends/base.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
+
+
+class ExecutionBackend(ABC):
+    @abstractmethod
+    def run(
+        self, plan: ExecutionPlan, artifact_dir: Path, config: ZakuroPocConfig
+    ) -> ExecutionResult:
+        pass

--- a/zakuro-poc-plugin/src/zakuro_poc/backends/docker_backend.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/backends/docker_backend.py
@@ -36,6 +36,8 @@ def build_docker_command(
             str(plan.resource_limits.cpu_count),
             "--memory",
             f"{plan.resource_limits.memory_mb}m",
+            "--user",
+            config.docker.user,
             "--pids-limit",
             str(config.docker.pids_limit),
             "--security-opt",

--- a/zakuro-poc-plugin/src/zakuro_poc/backends/docker_backend.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/backends/docker_backend.py
@@ -1,0 +1,180 @@
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from zakuro_poc.backends.base import ExecutionBackend
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.artifacts import write_text_artifact
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
+
+
+def docker_available() -> bool:
+    try:
+        subprocess.run(["docker", "version"], capture_output=True, timeout=5, check=True)
+        return True
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return False
+
+
+def build_docker_command(
+    plan: ExecutionPlan,
+    artifact_dir: Path,
+    config: ZakuroPocConfig,
+) -> list[str]:
+    cmd = ["docker", "run"]
+
+    if config.docker.remove_container:
+        cmd.append("--rm")
+
+    cmd.extend(
+        [
+            "--name",
+            f"zakuro-{artifact_dir.name}",
+            "--cpus",
+            str(plan.resource_limits.cpu_count),
+            "--memory",
+            f"{plan.resource_limits.memory_mb}m",
+        ]
+    )
+
+    if plan.network_enabled and config.allow_network:
+        cmd.extend(["--network", "bridge"])
+    else:
+        cmd.extend(["--network", "none"])
+
+    cmd.extend(
+        [
+            "-v",
+            f"{artifact_dir.absolute()}:/zakuro-artifacts",
+            "-v",
+            f"{artifact_dir.absolute()}/workspace:/workspace",
+            "-w",
+            "/workspace",
+        ]
+    )
+
+    cmd.append(plan.image)
+    cmd.extend(plan.command)
+
+    return cmd
+
+
+class DockerBackend(ExecutionBackend):
+    def run(
+        self, plan: ExecutionPlan, artifact_dir: Path, config: ZakuroPocConfig
+    ) -> ExecutionResult:
+        started_at = datetime.now(UTC)
+
+        if not docker_available():
+            finished_at = datetime.now(UTC)
+            duration_ms = int((finished_at - started_at).total_seconds() * 1000)
+            result = ExecutionResult(
+                job_id=artifact_dir.name,
+                job_name=plan.job_name,
+                backend="docker",
+                status="failed",
+                stdout="",
+                stderr="Docker is not available",
+                exit_code=None,
+                duration_ms=duration_ms,
+                artifact_dir=str(artifact_dir),
+                started_at=started_at,
+                finished_at=finished_at,
+                error_message="Docker CLI is not available or daemon is unreachable",
+            )
+            write_text_artifact(artifact_dir, "stdout.txt", "")
+            write_text_artifact(artifact_dir, "stderr.txt", result.stderr)
+            write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
+
+            metadata = {
+                "job_id": result.job_id,
+                "job_name": result.job_name,
+                "backend": result.backend,
+                "image": plan.image,
+                "command": plan.command,
+                "resource_limits": plan.resource_limits.model_dump(),
+                "started_at": result.started_at.isoformat(),
+                "finished_at": result.finished_at.isoformat(),
+                "duration_ms": result.duration_ms,
+                "status": result.status,
+            }
+            write_text_artifact(artifact_dir, "metadata.json", json.dumps(metadata, indent=2))
+            return result
+
+        workspace_dir = artifact_dir / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+
+        write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+
+        docker_cmd = build_docker_command(plan, artifact_dir, config)
+
+        stdout_data = ""
+        stderr_data = ""
+        exit_code = None
+        status = "failed"
+
+        try:
+            proc = subprocess.run(
+                docker_cmd,
+                capture_output=True,
+                timeout=plan.resource_limits.timeout_seconds,
+                text=True,
+            )
+            stdout_data = proc.stdout
+            stderr_data = proc.stderr
+            exit_code = proc.returncode
+            status = "succeeded" if exit_code == 0 else "failed"
+        except subprocess.TimeoutExpired as e:
+            status = "timed_out"
+            stdout_data = (
+                e.stdout.decode("utf-8", errors="replace")
+                if isinstance(e.stdout, bytes)
+                else (e.stdout or "")
+            )
+            stderr_data = (
+                e.stderr.decode("utf-8", errors="replace")
+                if isinstance(e.stderr, bytes)
+                else (e.stderr or "")
+            )
+            stderr_data += f"\nJob timed out after {plan.resource_limits.timeout_seconds} seconds"
+        except Exception as e:
+            status = "failed"
+            stderr_data = f"Failed to execute docker command: {e}"
+
+        finished_at = datetime.now(UTC)
+        duration_ms = int((finished_at - started_at).total_seconds() * 1000)
+
+        result = ExecutionResult(
+            job_id=artifact_dir.name,
+            job_name=plan.job_name,
+            backend="docker",
+            status=status,  # type: ignore
+            stdout=stdout_data,
+            stderr=stderr_data,
+            exit_code=exit_code,
+            duration_ms=duration_ms,
+            artifact_dir=str(artifact_dir),
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+        write_text_artifact(artifact_dir, "stdout.txt", stdout_data)
+        write_text_artifact(artifact_dir, "stderr.txt", stderr_data)
+        write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
+
+        metadata = {
+            "job_id": result.job_id,
+            "job_name": result.job_name,
+            "backend": result.backend,
+            "image": plan.image,
+            "command": plan.command,
+            "resource_limits": plan.resource_limits.model_dump(),
+            "started_at": result.started_at.isoformat(),
+            "finished_at": result.finished_at.isoformat(),
+            "duration_ms": result.duration_ms,
+            "status": result.status,
+        }
+        write_text_artifact(artifact_dir, "metadata.json", json.dumps(metadata, indent=2))
+
+        return result

--- a/zakuro-poc-plugin/src/zakuro_poc/backends/docker_backend.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/backends/docker_backend.py
@@ -1,11 +1,11 @@
-import json
 import subprocess
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import Literal, cast
 
 from zakuro_poc.backends.base import ExecutionBackend
 from zakuro_poc.config import ZakuroPocConfig
-from zakuro_poc.execution.artifacts import write_text_artifact
+from zakuro_poc.execution.artifacts import write_execution_artifacts
 from zakuro_poc.models import ExecutionPlan, ExecutionResult
 
 
@@ -22,6 +22,7 @@ def build_docker_command(
     artifact_dir: Path,
     config: ZakuroPocConfig,
 ) -> list[str]:
+    container_name = docker_container_name(artifact_dir)
     cmd = ["docker", "run"]
 
     if config.docker.remove_container:
@@ -30,18 +31,34 @@ def build_docker_command(
     cmd.extend(
         [
             "--name",
-            f"zakuro-{artifact_dir.name}",
+            container_name,
             "--cpus",
             str(plan.resource_limits.cpu_count),
             "--memory",
             f"{plan.resource_limits.memory_mb}m",
+            "--pids-limit",
+            str(config.docker.pids_limit),
+            "--security-opt",
+            "no-new-privileges",
+            "--cap-drop",
+            "ALL",
         ]
     )
 
+    if config.docker.read_only_root:
+        cmd.extend(["--read-only", "--tmpfs", "/tmp:rw,noexec,nosuid,size=64m"])
+
     if plan.network_enabled and config.allow_network:
-        cmd.extend(["--network", "bridge"])
+        cmd.extend(["--network", config.docker.network_mode])
     else:
         cmd.extend(["--network", "none"])
+
+    for key, value in sorted(plan.env.items()):
+        cmd.extend(["--env", f"{key}={value}"])
+
+    container_workdir = "/workspace"
+    if plan.working_dir:
+        container_workdir = str(PurePosixPath("/workspace") / PurePosixPath(plan.working_dir))
 
     cmd.extend(
         [
@@ -50,7 +67,7 @@ def build_docker_command(
             "-v",
             f"{artifact_dir.absolute()}/workspace:/workspace",
             "-w",
-            "/workspace",
+            container_workdir,
         ]
     )
 
@@ -58,6 +75,20 @@ def build_docker_command(
     cmd.extend(plan.command)
 
     return cmd
+
+
+def docker_container_name(artifact_dir: Path) -> str:
+    return f"zakuro-{artifact_dir.name}"
+
+
+def force_remove_container(container_name: str) -> None:
+    subprocess.run(
+        ["docker", "rm", "-f", container_name],
+        capture_output=True,
+        timeout=10,
+        check=False,
+        text=True,
+    )
 
 
 class DockerBackend(ExecutionBackend):
@@ -83,36 +114,17 @@ class DockerBackend(ExecutionBackend):
                 finished_at=finished_at,
                 error_message="Docker CLI is not available or daemon is unreachable",
             )
-            write_text_artifact(artifact_dir, "stdout.txt", "")
-            write_text_artifact(artifact_dir, "stderr.txt", result.stderr)
-            write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
-
-            metadata = {
-                "job_id": result.job_id,
-                "job_name": result.job_name,
-                "backend": result.backend,
-                "image": plan.image,
-                "command": plan.command,
-                "resource_limits": plan.resource_limits.model_dump(),
-                "started_at": result.started_at.isoformat(),
-                "finished_at": result.finished_at.isoformat(),
-                "duration_ms": result.duration_ms,
-                "status": result.status,
-            }
-            write_text_artifact(artifact_dir, "metadata.json", json.dumps(metadata, indent=2))
+            write_execution_artifacts(artifact_dir, plan, result)
             return result
 
-        workspace_dir = artifact_dir / "workspace"
-        workspace_dir.mkdir(parents=True, exist_ok=True)
-
-        write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
-
         docker_cmd = build_docker_command(plan, artifact_dir, config)
+        container_name = docker_container_name(artifact_dir)
 
         stdout_data = ""
         stderr_data = ""
         exit_code = None
-        status = "failed"
+        status: Literal["succeeded", "failed", "timed_out"] = "failed"
+        error_message = None
 
         try:
             proc = subprocess.run(
@@ -127,6 +139,8 @@ class DockerBackend(ExecutionBackend):
             status = "succeeded" if exit_code == 0 else "failed"
         except subprocess.TimeoutExpired as e:
             status = "timed_out"
+            if config.docker.remove_container:
+                force_remove_container(container_name)
             stdout_data = (
                 e.stdout.decode("utf-8", errors="replace")
                 if isinstance(e.stdout, bytes)
@@ -138,9 +152,11 @@ class DockerBackend(ExecutionBackend):
                 else (e.stderr or "")
             )
             stderr_data += f"\nJob timed out after {plan.resource_limits.timeout_seconds} seconds"
+            error_message = f"Job timed out after {plan.resource_limits.timeout_seconds} seconds"
         except Exception as e:
             status = "failed"
             stderr_data = f"Failed to execute docker command: {e}"
+            error_message = str(e)
 
         finished_at = datetime.now(UTC)
         duration_ms = int((finished_at - started_at).total_seconds() * 1000)
@@ -149,7 +165,7 @@ class DockerBackend(ExecutionBackend):
             job_id=artifact_dir.name,
             job_name=plan.job_name,
             backend="docker",
-            status=status,  # type: ignore
+            status=cast(Literal["succeeded", "failed", "timed_out", "rejected"], status),
             stdout=stdout_data,
             stderr=stderr_data,
             exit_code=exit_code,
@@ -157,24 +173,8 @@ class DockerBackend(ExecutionBackend):
             artifact_dir=str(artifact_dir),
             started_at=started_at,
             finished_at=finished_at,
+            error_message=error_message,
         )
 
-        write_text_artifact(artifact_dir, "stdout.txt", stdout_data)
-        write_text_artifact(artifact_dir, "stderr.txt", stderr_data)
-        write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
-
-        metadata = {
-            "job_id": result.job_id,
-            "job_name": result.job_name,
-            "backend": result.backend,
-            "image": plan.image,
-            "command": plan.command,
-            "resource_limits": plan.resource_limits.model_dump(),
-            "started_at": result.started_at.isoformat(),
-            "finished_at": result.finished_at.isoformat(),
-            "duration_ms": result.duration_ms,
-            "status": result.status,
-        }
-        write_text_artifact(artifact_dir, "metadata.json", json.dumps(metadata, indent=2))
-
+        write_execution_artifacts(artifact_dir, plan, result)
         return result

--- a/zakuro-poc-plugin/src/zakuro_poc/backends/noop_backend.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/backends/noop_backend.py
@@ -1,0 +1,57 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from zakuro_poc.backends.base import ExecutionBackend
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.artifacts import write_text_artifact
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
+
+
+class NoopBackend(ExecutionBackend):
+    def run(
+        self,
+        plan: ExecutionPlan,
+        artifact_dir: Path,
+        config: ZakuroPocConfig,  # noqa: ARG002
+    ) -> ExecutionResult:
+        started_at = datetime.now(UTC)
+
+        stdout = f"NoopBackend: Executing plan {plan.job_name}\nCommand: {plan.command}"
+        write_text_artifact(artifact_dir, "stdout.txt", stdout)
+        write_text_artifact(artifact_dir, "stderr.txt", "")
+
+        finished_at = datetime.now(UTC)
+        duration_ms = int((finished_at - started_at).total_seconds() * 1000)
+
+        result = ExecutionResult(
+            job_id=artifact_dir.name,
+            job_name=plan.job_name,
+            backend="noop",
+            status="succeeded",
+            stdout=stdout,
+            stderr="",
+            exit_code=0,
+            duration_ms=duration_ms,
+            artifact_dir=str(artifact_dir),
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+        write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
+
+        metadata = {
+            "job_id": result.job_id,
+            "job_name": result.job_name,
+            "backend": result.backend,
+            "image": plan.image,
+            "command": plan.command,
+            "resource_limits": plan.resource_limits.model_dump(),
+            "started_at": result.started_at.isoformat(),
+            "finished_at": result.finished_at.isoformat(),
+            "duration_ms": result.duration_ms,
+            "status": result.status,
+        }
+        write_text_artifact(artifact_dir, "metadata.json", json.dumps(metadata, indent=2))
+
+        return result

--- a/zakuro-poc-plugin/src/zakuro_poc/backends/zakuro_backend.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/backends/zakuro_backend.py
@@ -1,0 +1,90 @@
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal, cast
+
+from zakuro_poc.backends.base import ExecutionBackend
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
+
+
+def build_zakuro_command(
+    plan_file: Path,
+    config: ZakuroPocConfig,
+) -> list[str]:
+    return [
+        config.zakuro.executable,
+        *config.zakuro.execute_args,
+        config.zakuro.plan_arg,
+        str(plan_file),
+        config.zakuro.json_arg,
+    ]
+
+
+class ZakuroBackend(ExecutionBackend):
+    def run(
+        self, plan: ExecutionPlan, artifact_dir: Path, config: ZakuroPocConfig
+    ) -> ExecutionResult:
+        started_at = datetime.now(UTC)
+        plan_file = artifact_dir / "plan.json"
+        command = build_zakuro_command(plan_file, config)
+
+        stdout_data = ""
+        stderr_data = ""
+        exit_code = None
+        status: Literal["succeeded", "failed", "timed_out"] = "failed"
+        error_message = None
+
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                timeout=plan.resource_limits.timeout_seconds,
+                text=True,
+            )
+            stdout_data = proc.stdout
+            stderr_data = proc.stderr
+            exit_code = proc.returncode
+            status = "succeeded" if exit_code == 0 else "failed"
+            if proc.returncode != 0:
+                error_message = "zc execute returned a non-zero exit code"
+        except FileNotFoundError:
+            stderr_data = f"Zakuro executable not found: {config.zakuro.executable}"
+            error_message = stderr_data
+        except subprocess.TimeoutExpired as e:
+            status = "timed_out"
+            stdout_data = (
+                e.stdout.decode("utf-8", errors="replace")
+                if isinstance(e.stdout, bytes)
+                else (e.stdout or "")
+            )
+            stderr_data = (
+                e.stderr.decode("utf-8", errors="replace")
+                if isinstance(e.stderr, bytes)
+                else (e.stderr or "")
+            )
+            stderr_data += (
+                f"\nZakuro execution timed out after {plan.resource_limits.timeout_seconds} seconds"
+            )
+            error_message = (
+                f"Zakuro execution timed out after {plan.resource_limits.timeout_seconds} seconds"
+            )
+        except Exception as e:
+            stderr_data = f"Failed to execute Zakuro command: {e}"
+            error_message = str(e)
+
+        finished_at = datetime.now(UTC)
+        return ExecutionResult(
+            job_id=artifact_dir.name,
+            job_name=plan.job_name,
+            backend="zakuro",
+            status=cast(Literal["succeeded", "failed", "timed_out", "rejected"], status),
+            stdout=stdout_data,
+            stderr=stderr_data,
+            exit_code=exit_code,
+            duration_ms=int((finished_at - started_at).total_seconds() * 1000),
+            artifact_dir=str(artifact_dir),
+            started_at=started_at,
+            finished_at=finished_at,
+            error_message=error_message,
+        )

--- a/zakuro-poc-plugin/src/zakuro_poc/cli.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/cli.py
@@ -199,4 +199,4 @@ def doctor() -> None:
 
 
 if __name__ == "__main__":
-    app()
+    app()  # pragma: no cover

--- a/zakuro-poc-plugin/src/zakuro_poc/cli.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/cli.py
@@ -1,0 +1,187 @@
+import json
+import sys
+from pathlib import Path
+
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+
+from zakuro_poc.backends.docker_backend import docker_available
+from zakuro_poc.config import load_config
+from zakuro_poc.execution.runner import execute_plan
+from zakuro_poc.models import ExecutionPlan
+from zakuro_poc.validation import validate_plan_or_raise
+
+app = typer.Typer(help="Zakuro POC Plugin CLI")
+console = Console()
+
+
+def load_plan(plan_path: Path) -> ExecutionPlan:
+    try:
+        data = json.loads(plan_path.read_text(encoding="utf-8"))
+        return ExecutionPlan(**data)
+    except FileNotFoundError:
+        console.print(f"[red]Error: Plan file not found at {plan_path}[/red]")
+        raise typer.Exit(1) from None
+    except json.JSONDecodeError as e:
+        console.print(f"[red]Error: Invalid JSON in plan: {e}[/red]")
+        raise typer.Exit(1) from e
+    except ValidationError as e:
+        console.print(f"[red]Error: Plan does not match schema: {e}[/red]")
+        raise typer.Exit(1) from e
+
+
+@app.command()
+def version():
+    """Print package version."""
+    import importlib.metadata
+
+    try:
+        v = importlib.metadata.version("zakuro-poc-plugin")
+        print(f"zakuro-poc-plugin {v}")
+    except importlib.metadata.PackageNotFoundError:
+        print("zakuro-poc-plugin version unknown")
+
+
+@app.command()
+def validate(plan: Path = typer.Option(..., help="Path to the JSON plan")) -> None:  # noqa: B008
+    """Validate a plan without executing it."""
+    p = load_plan(plan)
+    try:
+        validate_plan_or_raise(p)
+        console.print("[green]Plan is valid.[/green]")
+        raise typer.Exit(0) from None
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from e
+
+
+@app.command("plan-show")
+def plan_show(plan: Path = typer.Option(..., help="Path to the JSON plan")) -> None:  # noqa: B008
+    """Show human-readable plan details."""
+    p = load_plan(plan)
+    console.print(f"[bold]Job Name:[/bold] {p.job_name}")
+    console.print(f"[bold]Backend:[/bold] {p.backend}")
+    console.print(f"[bold]Image:[/bold] {p.image}")
+    console.print(f"[bold]Command:[/bold] {p.command}")
+    console.print(f"[bold]Network Enabled:[/bold] {p.network_enabled}")
+    console.print(f"[bold]Repository URL:[/bold] {p.repo_url}")
+    console.print(f"[bold]CPU Count:[/bold] {p.resource_limits.cpu_count}")
+    console.print(f"[bold]Memory (MB):[/bold] {p.resource_limits.memory_mb}")
+    console.print(f"[bold]Timeout (s):[/bold] {p.resource_limits.timeout_seconds}")
+
+
+@app.command()
+def execute(
+    plan: Path = typer.Option(..., help="Path to the JSON plan"),  # noqa: B008
+    config_path: Path | None = typer.Option(None, "--config", help="Path to custom config"),  # noqa: B008
+    yes: bool = typer.Option(False, "--yes", help="Skip confirmation prompt"),  # noqa: B008
+    json_output: bool = typer.Option(False, "--json", help="Output JSON result only"),  # noqa: B008
+) -> None:
+    """Execute a plan."""
+    config = load_config(str(config_path) if config_path else None)
+    p = load_plan(plan)
+
+    if not json_output:
+        # Show plan but don't require --plan argument manually
+        console.print(f"[bold]Job Name:[/bold] {p.job_name}")
+        console.print(f"[bold]Backend:[/bold] {p.backend}")
+        console.print(f"[bold]Image:[/bold] {p.image}")
+        console.print(f"[bold]Command:[/bold] {p.command}")
+        console.print(f"[bold]Network Enabled:[/bold] {p.network_enabled}")
+        console.print(f"[bold]Repository URL:[/bold] {p.repo_url}")
+        console.print(f"[bold]CPU Count:[/bold] {p.resource_limits.cpu_count}")
+        console.print(f"[bold]Memory (MB):[/bold] {p.resource_limits.memory_mb}")
+        console.print(f"[bold]Timeout (s):[/bold] {p.resource_limits.timeout_seconds}")
+        console.print("-" * 40)
+
+    if not yes:
+        confirmation = typer.prompt("Type 'yes' to execute")
+        if confirmation != "yes":
+            console.print("[yellow]Execution aborted.[/yellow]")
+            raise typer.Exit(1) from None
+
+    try:
+        result = execute_plan(p, config)
+    except ValueError as e:
+        if not json_output:
+            console.print(f"[red]Validation rejected: {e}[/red]")
+        raise typer.Exit(2) from e
+
+    if json_output:
+        print(result.model_dump_json(indent=2))
+    else:
+        console.print("\n[bold]Execution Result[/bold]")
+        console.print(f"Status: {result.status}")
+        console.print(f"Exit Code: {result.exit_code}")
+        console.print(f"Duration (ms): {result.duration_ms}")
+        console.print(f"Artifact Dir: {result.artifact_dir}")
+        console.print("\n[bold]Stdout:[/bold]")
+        print(result.stdout)
+        if result.stderr:
+            console.print("\n[bold]Stderr:[/bold]")
+            print(result.stderr)
+
+    if result.status == "succeeded":
+        raise typer.Exit(0)
+    elif result.status == "timed_out":
+        raise typer.Exit(124)
+    else:
+        raise typer.Exit(1)
+
+
+@app.command()
+def doctor() -> None:
+    """Check system readiness."""
+    all_ok = True
+
+    # Python version
+    v = sys.version_info
+    if v.major >= 3 and v.minor >= 11:
+        console.print("[green][OK] Python >= 3.11[/green]")
+    else:
+        console.print("[red][FAIL] Python >= 3.11[/red]")
+        all_ok = False
+
+    # Package import
+    try:
+        import zakuro_poc  # noqa
+
+        console.print("[green][OK] Package imported[/green]")
+    except ImportError:
+        console.print("[red][FAIL] Package import failed[/red]")
+        all_ok = False
+
+    # Config load
+    try:
+        config = load_config()
+        console.print("[green][OK] Config loaded[/green]")
+    except Exception as e:
+        console.print(f"[red][FAIL] Config load failed: {e}[/red]")
+        all_ok = False
+
+    # Artifact root writable
+    if "config" in locals():
+        artifact_root = Path(config.artifact_root)
+        try:
+            artifact_root.mkdir(parents=True, exist_ok=True)
+            test_file = artifact_root / ".test"
+            test_file.touch()
+            test_file.unlink()
+            console.print("[green][OK] Artifact root writable[/green]")
+        except Exception as e:
+            console.print(f"[red][FAIL] Artifact root not writable: {e}[/red]")
+            all_ok = False
+
+    # Docker checks
+    if docker_available():
+        console.print("[green][OK] Docker CLI available and daemon reachable[/green]")
+    else:
+        console.print("[yellow][WARN] Docker daemon not reachable or CLI not available[/yellow]")
+
+    if not all_ok:
+        raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/zakuro-poc-plugin/src/zakuro_poc/cli.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/cli.py
@@ -7,18 +7,21 @@ from pydantic import ValidationError
 from rich.console import Console
 
 from zakuro_poc.backends.docker_backend import docker_available
-from zakuro_poc.config import load_config
+from zakuro_poc.config import ZakuroPocConfig, load_config
 from zakuro_poc.execution.runner import execute_plan
-from zakuro_poc.models import ExecutionPlan
-from zakuro_poc.validation import validate_plan_or_raise
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
+from zakuro_poc.validation import validate_plan, validate_plan_or_raise
 
 app = typer.Typer(help="Zakuro POC Plugin CLI")
 console = Console()
 
 
-def load_plan(plan_path: Path) -> ExecutionPlan:
+def load_plan(plan_path: Path, config: ZakuroPocConfig | None = None) -> ExecutionPlan:
     try:
         data = json.loads(plan_path.read_text(encoding="utf-8"))
+        if config is not None:
+            data.setdefault("backend", config.default_backend)
+            data.setdefault("image", config.default_image)
         return ExecutionPlan(**data)
     except FileNotFoundError:
         console.print(f"[red]Error: Plan file not found at {plan_path}[/red]")
@@ -29,6 +32,31 @@ def load_plan(plan_path: Path) -> ExecutionPlan:
     except ValidationError as e:
         console.print(f"[red]Error: Plan does not match schema: {e}[/red]")
         raise typer.Exit(1) from e
+
+
+def print_plan(plan: ExecutionPlan) -> None:
+    console.print(f"[bold]Job Name:[/bold] {plan.job_name}")
+    console.print(f"[bold]Backend:[/bold] {plan.backend}")
+    console.print(f"[bold]Image:[/bold] {plan.image}")
+    console.print(f"[bold]Command:[/bold] {plan.command}")
+    console.print(f"[bold]Network Enabled:[/bold] {plan.network_enabled}")
+    console.print(f"[bold]Repository URL:[/bold] {plan.repo_url}")
+    console.print(f"[bold]CPU Count:[/bold] {plan.resource_limits.cpu_count}")
+    console.print(f"[bold]Memory (MB):[/bold] {plan.resource_limits.memory_mb}")
+    console.print(f"[bold]Timeout (s):[/bold] {plan.resource_limits.timeout_seconds}")
+
+
+def print_result(result: ExecutionResult) -> None:
+    console.print("\n[bold]Execution Result[/bold]")
+    console.print(f"Status: {result.status}")
+    console.print(f"Exit Code: {result.exit_code}")
+    console.print(f"Duration (ms): {result.duration_ms}")
+    console.print(f"Artifact Dir: {result.artifact_dir}")
+    console.print("\n[bold]Stdout:[/bold]")
+    print(result.stdout)
+    if result.stderr:
+        console.print("\n[bold]Stderr:[/bold]")
+        print(result.stderr)
 
 
 @app.command()
@@ -44,11 +72,17 @@ def version():
 
 
 @app.command()
-def validate(plan: Path = typer.Option(..., help="Path to the JSON plan")) -> None:  # noqa: B008
+def validate(  # noqa: B008
+    plan: Path = typer.Option(..., help="Path to the JSON plan"),  # noqa: B008
+    config_path: Path | None = typer.Option(  # noqa: B008
+        None, "--config", help="Path to custom config"
+    ),
+) -> None:
     """Validate a plan without executing it."""
-    p = load_plan(plan)
+    config = load_config(str(config_path) if config_path else None)
+    p = load_plan(plan, config)
     try:
-        validate_plan_or_raise(p)
+        validate_plan_or_raise(p, config)
         console.print("[green]Plan is valid.[/green]")
         raise typer.Exit(0) from None
     except ValueError as e:
@@ -60,15 +94,7 @@ def validate(plan: Path = typer.Option(..., help="Path to the JSON plan")) -> No
 def plan_show(plan: Path = typer.Option(..., help="Path to the JSON plan")) -> None:  # noqa: B008
     """Show human-readable plan details."""
     p = load_plan(plan)
-    console.print(f"[bold]Job Name:[/bold] {p.job_name}")
-    console.print(f"[bold]Backend:[/bold] {p.backend}")
-    console.print(f"[bold]Image:[/bold] {p.image}")
-    console.print(f"[bold]Command:[/bold] {p.command}")
-    console.print(f"[bold]Network Enabled:[/bold] {p.network_enabled}")
-    console.print(f"[bold]Repository URL:[/bold] {p.repo_url}")
-    console.print(f"[bold]CPU Count:[/bold] {p.resource_limits.cpu_count}")
-    console.print(f"[bold]Memory (MB):[/bold] {p.resource_limits.memory_mb}")
-    console.print(f"[bold]Timeout (s):[/bold] {p.resource_limits.timeout_seconds}")
+    print_plan(p)
 
 
 @app.command()
@@ -80,19 +106,20 @@ def execute(
 ) -> None:
     """Execute a plan."""
     config = load_config(str(config_path) if config_path else None)
-    p = load_plan(plan)
+    p = load_plan(plan, config)
+
+    violations = validate_plan(p, config)
+    if violations:
+        result = execute_plan(p, config)
+        if json_output:
+            print(result.model_dump_json(indent=2))
+        else:
+            console.print(f"[red]Validation rejected: {'; '.join(violations)}[/red]")
+            print_result(result)
+        raise typer.Exit(2) from None
 
     if not json_output:
-        # Show plan but don't require --plan argument manually
-        console.print(f"[bold]Job Name:[/bold] {p.job_name}")
-        console.print(f"[bold]Backend:[/bold] {p.backend}")
-        console.print(f"[bold]Image:[/bold] {p.image}")
-        console.print(f"[bold]Command:[/bold] {p.command}")
-        console.print(f"[bold]Network Enabled:[/bold] {p.network_enabled}")
-        console.print(f"[bold]Repository URL:[/bold] {p.repo_url}")
-        console.print(f"[bold]CPU Count:[/bold] {p.resource_limits.cpu_count}")
-        console.print(f"[bold]Memory (MB):[/bold] {p.resource_limits.memory_mb}")
-        console.print(f"[bold]Timeout (s):[/bold] {p.resource_limits.timeout_seconds}")
+        print_plan(p)
         console.print("-" * 40)
 
     if not yes:
@@ -101,31 +128,19 @@ def execute(
             console.print("[yellow]Execution aborted.[/yellow]")
             raise typer.Exit(1) from None
 
-    try:
-        result = execute_plan(p, config)
-    except ValueError as e:
-        if not json_output:
-            console.print(f"[red]Validation rejected: {e}[/red]")
-        raise typer.Exit(2) from e
+    result = execute_plan(p, config)
 
     if json_output:
         print(result.model_dump_json(indent=2))
     else:
-        console.print("\n[bold]Execution Result[/bold]")
-        console.print(f"Status: {result.status}")
-        console.print(f"Exit Code: {result.exit_code}")
-        console.print(f"Duration (ms): {result.duration_ms}")
-        console.print(f"Artifact Dir: {result.artifact_dir}")
-        console.print("\n[bold]Stdout:[/bold]")
-        print(result.stdout)
-        if result.stderr:
-            console.print("\n[bold]Stderr:[/bold]")
-            print(result.stderr)
+        print_result(result)
 
     if result.status == "succeeded":
         raise typer.Exit(0)
     elif result.status == "timed_out":
         raise typer.Exit(124)
+    elif result.status == "rejected":
+        raise typer.Exit(2)
     else:
         raise typer.Exit(1)
 

--- a/zakuro-poc-plugin/src/zakuro_poc/config.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/config.py
@@ -9,6 +9,7 @@ class DockerConfig(BaseModel):
     remove_container: bool = True
     read_only_root: bool = False
     network_mode: Literal["none", "bridge"] = "none"
+    pids_limit: int = Field(default=256, ge=1)
 
 
 class ZakuroPocConfig(BaseModel):

--- a/zakuro-poc-plugin/src/zakuro_poc/config.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/config.py
@@ -10,6 +10,14 @@ class DockerConfig(BaseModel):
     read_only_root: bool = False
     network_mode: Literal["none", "bridge"] = "none"
     pids_limit: int = Field(default=256, ge=1)
+    user: str = "65532:65532"
+
+
+class ZakuroBackendConfig(BaseModel):
+    executable: str = Field(default="zc", min_length=1)
+    execute_args: list[str] = Field(default_factory=lambda: ["execute"])
+    plan_arg: str = "--plan"
+    json_arg: str = "--json"
 
 
 class ZakuroPocConfig(BaseModel):
@@ -23,6 +31,7 @@ class ZakuroPocConfig(BaseModel):
     max_memory_mb: int = Field(default=4096, ge=128)
     max_cpu_count: float = Field(default=4.0, gt=0.0)
     docker: DockerConfig = Field(default_factory=DockerConfig)
+    zakuro: ZakuroBackendConfig = Field(default_factory=ZakuroBackendConfig)
 
 
 def load_config(path: str | None = None) -> ZakuroPocConfig:

--- a/zakuro-poc-plugin/src/zakuro_poc/config.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/config.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class DockerConfig(BaseModel):
+    remove_container: bool = True
+    read_only_root: bool = False
+    network_mode: Literal["none", "bridge"] = "none"
+
+
+class ZakuroPocConfig(BaseModel):
+    artifact_root: str = Field(default="./zakuro-artifacts", min_length=1)
+    default_backend: str = "docker"
+    default_image: str = "python:3.11-slim"
+    allow_network: bool = False
+    allow_shell: bool = False
+    allow_latest_images: bool = False
+    max_timeout_seconds: int = Field(default=3600, ge=1)
+    max_memory_mb: int = Field(default=4096, ge=128)
+    max_cpu_count: float = Field(default=4.0, gt=0.0)
+    docker: DockerConfig = Field(default_factory=DockerConfig)
+
+
+def load_config(path: str | None = None) -> ZakuroPocConfig:
+    search_paths = []
+    if path:
+        search_paths.append(Path(path))
+    else:
+        search_paths.extend(
+            [
+                Path("./zakuro-poc.json"),
+                Path("~/.claude/zakuro-poc.json").expanduser(),
+                Path(__file__).parent.parent.parent / "config" / "zakuro-poc.example.json",
+            ]
+        )
+
+    for p in search_paths:
+        if p.is_file():
+            try:
+                with open(p, encoding="utf-8") as f:
+                    data = json.load(f)
+                return ZakuroPocConfig(**data)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON in config {p}: {e}") from e
+
+    # Fallback to built-in defaults
+    return ZakuroPocConfig()

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
@@ -1,5 +1,8 @@
+import json
 import re
 from pathlib import Path
+
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
 
 
 def _is_safe_job_id(job_id: str) -> bool:
@@ -17,6 +20,7 @@ def create_artifact_dir(root: Path, job_id: str) -> Path:
         raise ValueError("Path traversal detected")
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / "workspace").mkdir(parents=True, exist_ok=True)
     return artifact_dir
 
 
@@ -30,3 +34,27 @@ def write_text_artifact(path: Path, name: str, content: str) -> Path:
 
     file_path.write_text(content, encoding="utf-8")
     return file_path
+
+
+def write_execution_artifacts(
+    artifact_dir: Path, plan: ExecutionPlan, result: ExecutionResult
+) -> None:
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    write_text_artifact(artifact_dir, "stdout.txt", result.stdout)
+    write_text_artifact(artifact_dir, "stderr.txt", result.stderr)
+    write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
+
+    metadata = {
+        "job_id": result.job_id,
+        "job_name": result.job_name,
+        "backend": result.backend,
+        "image": plan.image,
+        "command": plan.command,
+        "resource_limits": plan.resource_limits.model_dump(),
+        "started_at": result.started_at.isoformat(),
+        "finished_at": result.finished_at.isoformat(),
+        "duration_ms": result.duration_ms,
+        "status": result.status,
+        "error_message": result.error_message,
+    }
+    write_text_artifact(artifact_dir, "metadata.json", json.dumps(metadata, indent=2))

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from pathlib import Path
 
@@ -20,7 +21,10 @@ def create_artifact_dir(root: Path, job_id: str) -> Path:
         raise ValueError("Path traversal detected")
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
-    (artifact_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    workspace_dir = artifact_dir / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(artifact_dir, 0o777)
+    os.chmod(workspace_dir, 0o777)
     return artifact_dir
 
 

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
@@ -17,7 +17,7 @@ def create_artifact_dir(root: Path, job_id: str) -> Path:
     root.mkdir(parents=True, exist_ok=True)
 
     artifact_dir = root / job_id
-    if not artifact_dir.resolve().is_relative_to(root.resolve()):
+    if not artifact_dir.resolve().is_relative_to(root.resolve()):  # pragma: no cover
         raise ValueError("Path traversal detected")
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -33,7 +33,7 @@ def write_text_artifact(path: Path, name: str, content: str) -> Path:
         raise ValueError("Invalid artifact name")
 
     file_path = path / name
-    if not file_path.resolve().is_relative_to(path.resolve()):
+    if not file_path.resolve().is_relative_to(path.resolve()):  # pragma: no cover
         raise ValueError("Path traversal detected in artifact name")
 
     file_path.write_text(content, encoding="utf-8")

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
@@ -20,9 +20,13 @@ def create_artifact_dir(root: Path, job_id: str) -> Path:
     if not artifact_dir.resolve().is_relative_to(root.resolve()):  # pragma: no cover
         raise ValueError("Path traversal detected")
 
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    workspace_dir = artifact_dir / "workspace"
-    workspace_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        artifact_dir.mkdir(parents=False, exist_ok=False)
+        workspace_dir = artifact_dir / "workspace"
+        workspace_dir.mkdir(parents=False, exist_ok=False)
+    except FileExistsError:
+        raise RuntimeError(f"Artifact directory collision for job {job_id}") from None
+
     os.chmod(artifact_dir, 0o777)
     os.chmod(workspace_dir, 0o777)
     return artifact_dir

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/artifacts.py
@@ -1,0 +1,32 @@
+import re
+from pathlib import Path
+
+
+def _is_safe_job_id(job_id: str) -> bool:
+    return bool(re.match(r"^[A-Za-z0-9_-]+$", job_id))
+
+
+def create_artifact_dir(root: Path, job_id: str) -> Path:
+    if not _is_safe_job_id(job_id):
+        raise ValueError("Unsafe job ID")
+
+    root.mkdir(parents=True, exist_ok=True)
+
+    artifact_dir = root / job_id
+    if not artifact_dir.resolve().is_relative_to(root.resolve()):
+        raise ValueError("Path traversal detected")
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    return artifact_dir
+
+
+def write_text_artifact(path: Path, name: str, content: str) -> Path:
+    if ".." in name or "/" in name or "\\" in name:
+        raise ValueError("Invalid artifact name")
+
+    file_path = path / name
+    if not file_path.resolve().is_relative_to(path.resolve()):
+        raise ValueError("Path traversal detected in artifact name")
+
+    file_path.write_text(content, encoding="utf-8")
+    return file_path

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/ids.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/ids.py
@@ -1,0 +1,8 @@
+import secrets
+from datetime import datetime
+
+
+def new_job_id(prefix: str = "job") -> str:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    random_hex = secrets.token_hex(4)
+    return f"{prefix}-{timestamp}-{random_hex}"

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/runner.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/runner.py
@@ -1,14 +1,22 @@
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
 from zakuro_poc.backends.base import ExecutionBackend
 from zakuro_poc.backends.docker_backend import DockerBackend
 from zakuro_poc.backends.noop_backend import NoopBackend
+from zakuro_poc.backends.zakuro_backend import ZakuroBackend
 from zakuro_poc.config import ZakuroPocConfig
-from zakuro_poc.execution.artifacts import create_artifact_dir, write_execution_artifacts
+from zakuro_poc.execution.artifacts import (
+    create_artifact_dir,
+    write_execution_artifacts,
+    write_text_artifact,
+)
 from zakuro_poc.execution.ids import new_job_id
 from zakuro_poc.models import ExecutionPlan, ExecutionResult
 from zakuro_poc.validation import validate_plan_or_raise
+
+BackendFactory = Callable[[str], ExecutionBackend | None]
 
 
 def _new_artifact_dir(config: ZakuroPocConfig) -> Path:
@@ -38,9 +46,20 @@ def _build_rejected_result(
     )
 
 
+def default_backend_factory(backend_name: str) -> ExecutionBackend | None:
+    if backend_name == "noop":
+        return NoopBackend()
+    if backend_name == "docker":
+        return DockerBackend()
+    if backend_name == "zakuro":
+        return ZakuroBackend()
+    return None
+
+
 def execute_plan(
     plan: ExecutionPlan,
     config: ZakuroPocConfig,
+    backend_factory: BackendFactory = default_backend_factory,
 ) -> ExecutionResult:
     started_at = datetime.now(UTC)
 
@@ -53,17 +72,15 @@ def execute_plan(
         return result
 
     artifact_dir = _new_artifact_dir(config)
-    if plan.backend == "noop":
-        backend: ExecutionBackend = NoopBackend()
-    elif plan.backend == "docker":
-        backend = DockerBackend()
-    else:
+    backend = backend_factory(plan.backend)
+    if backend is None:
         result = _build_rejected_result(
             plan, artifact_dir, started_at, f"Unknown backend: {plan.backend}"
         )
         write_execution_artifacts(artifact_dir, plan, result)
         return result
 
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
     result = backend.run(plan, artifact_dir, config)
     write_execution_artifacts(artifact_dir, plan, result)
     return result

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/runner.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/runner.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from zakuro_poc.backends.base import ExecutionBackend
+from zakuro_poc.backends.docker_backend import DockerBackend
+from zakuro_poc.backends.noop_backend import NoopBackend
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.artifacts import create_artifact_dir, write_text_artifact
+from zakuro_poc.execution.ids import new_job_id
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
+from zakuro_poc.validation import validate_plan_or_raise
+
+
+def execute_plan(
+    plan: ExecutionPlan,
+    config: ZakuroPocConfig,
+) -> ExecutionResult:
+    # 1. create job ID
+    job_id = new_job_id()
+
+    # 2. create artifact directory
+    root_path = Path(config.artifact_root)
+    artifact_dir = create_artifact_dir(root_path, job_id)
+
+    # 3. write plan
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+
+    # 4. validate plan
+    validate_plan_or_raise(plan)
+
+    # 5. select backend
+    if plan.backend == "noop":
+        backend: ExecutionBackend = NoopBackend()
+    elif plan.backend == "docker":
+        backend = DockerBackend()
+    else:
+        raise ValueError(f"Unknown backend: {plan.backend}")
+
+    # 6. execute backend
+    result = backend.run(plan, artifact_dir, config)
+
+    # 7. write result
+    write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
+
+    # 8. return result
+    return result

--- a/zakuro-poc-plugin/src/zakuro_poc/execution/runner.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/execution/runner.py
@@ -1,45 +1,69 @@
+from datetime import UTC, datetime
 from pathlib import Path
 
 from zakuro_poc.backends.base import ExecutionBackend
 from zakuro_poc.backends.docker_backend import DockerBackend
 from zakuro_poc.backends.noop_backend import NoopBackend
 from zakuro_poc.config import ZakuroPocConfig
-from zakuro_poc.execution.artifacts import create_artifact_dir, write_text_artifact
+from zakuro_poc.execution.artifacts import create_artifact_dir, write_execution_artifacts
 from zakuro_poc.execution.ids import new_job_id
 from zakuro_poc.models import ExecutionPlan, ExecutionResult
 from zakuro_poc.validation import validate_plan_or_raise
+
+
+def _new_artifact_dir(config: ZakuroPocConfig) -> Path:
+    return create_artifact_dir(Path(config.artifact_root), new_job_id())
+
+
+def _build_rejected_result(
+    plan: ExecutionPlan,
+    artifact_dir: Path,
+    started_at: datetime,
+    error_message: str,
+) -> ExecutionResult:
+    finished_at = datetime.now(UTC)
+    return ExecutionResult(
+        job_id=artifact_dir.name,
+        job_name=plan.job_name,
+        backend=plan.backend,
+        status="rejected",
+        stdout="",
+        stderr=error_message,
+        exit_code=None,
+        duration_ms=int((finished_at - started_at).total_seconds() * 1000),
+        artifact_dir=str(artifact_dir),
+        started_at=started_at,
+        finished_at=finished_at,
+        error_message=error_message,
+    )
 
 
 def execute_plan(
     plan: ExecutionPlan,
     config: ZakuroPocConfig,
 ) -> ExecutionResult:
-    # 1. create job ID
-    job_id = new_job_id()
+    started_at = datetime.now(UTC)
 
-    # 2. create artifact directory
-    root_path = Path(config.artifact_root)
-    artifact_dir = create_artifact_dir(root_path, job_id)
+    try:
+        validate_plan_or_raise(plan, config)
+    except ValueError as e:
+        artifact_dir = _new_artifact_dir(config)
+        result = _build_rejected_result(plan, artifact_dir, started_at, str(e))
+        write_execution_artifacts(artifact_dir, plan, result)
+        return result
 
-    # 3. write plan
-    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
-
-    # 4. validate plan
-    validate_plan_or_raise(plan)
-
-    # 5. select backend
+    artifact_dir = _new_artifact_dir(config)
     if plan.backend == "noop":
         backend: ExecutionBackend = NoopBackend()
     elif plan.backend == "docker":
         backend = DockerBackend()
     else:
-        raise ValueError(f"Unknown backend: {plan.backend}")
+        result = _build_rejected_result(
+            plan, artifact_dir, started_at, f"Unknown backend: {plan.backend}"
+        )
+        write_execution_artifacts(artifact_dir, plan, result)
+        return result
 
-    # 6. execute backend
     result = backend.run(plan, artifact_dir, config)
-
-    # 7. write result
-    write_text_artifact(artifact_dir, "result.json", result.model_dump_json(indent=2))
-
-    # 8. return result
+    write_execution_artifacts(artifact_dir, plan, result)
     return result

--- a/zakuro-poc-plugin/src/zakuro_poc/models.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/models.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-BackendType = Literal["noop", "docker"]
+BackendType = Literal["noop", "docker", "zakuro"]
 JobStatus = Literal["succeeded", "failed", "timed_out", "rejected"]
 
 

--- a/zakuro-poc-plugin/src/zakuro_poc/models.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/models.py
@@ -1,0 +1,63 @@
+import re
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+BackendType = Literal["noop", "docker"]
+JobStatus = Literal["succeeded", "failed", "timed_out", "rejected"]
+
+
+class ArtifactInfo(BaseModel):
+    path: str
+
+
+class ResourceLimits(BaseModel):
+    cpu_count: float = Field(default=1.0, gt=0.0)
+    memory_mb: int = Field(default=512, ge=128)
+    gpu_count: int = Field(default=0, ge=0)
+    timeout_seconds: int = Field(default=60, ge=1, le=3600)
+
+
+class ExecutionPlan(BaseModel):
+    job_name: str = Field(min_length=1)
+    backend: BackendType = "docker"
+    image: str = Field(default="python:3.11-slim", min_length=1)
+    command: list[str] = Field(min_length=1)
+    working_dir: str | None = None
+    repo_url: str | None = None
+    env: dict[str, str] = Field(default_factory=dict)
+    resource_limits: ResourceLimits = Field(default_factory=ResourceLimits)
+    artifact_dir: str | None = None
+    network_enabled: bool = False
+    created_by: str = "claude-code"
+
+    @field_validator("repo_url")
+    @classmethod
+    def validate_repo_url(cls, v: str | None) -> str | None:
+        if v is not None and not v.startswith("https://"):
+            raise ValueError("repo_url must be HTTPS")
+        return v
+
+    @field_validator("env")
+    @classmethod
+    def validate_env_keys(cls, v: dict[str, str]) -> dict[str, str]:
+        for key in v:
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                raise ValueError(f"invalid environment variable name: {key}")
+        return v
+
+
+class ExecutionResult(BaseModel):
+    job_id: str
+    job_name: str
+    backend: str
+    status: JobStatus
+    stdout: str
+    stderr: str
+    exit_code: int | None
+    duration_ms: int
+    artifact_dir: str
+    started_at: datetime
+    finished_at: datetime
+    error_message: str | None = None

--- a/zakuro-poc-plugin/src/zakuro_poc/observability/logging.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/observability/logging.py
@@ -1,0 +1,8 @@
+import logging
+
+
+def configure_logging(verbose: bool = False) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level, format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )

--- a/zakuro-poc-plugin/src/zakuro_poc/security/policy.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/security/policy.py
@@ -1,0 +1,30 @@
+from zakuro_poc.models import ExecutionPlan
+
+
+def validate_security_policy(plan: ExecutionPlan) -> list[str]:
+    violations = []
+    if not plan.command:
+        violations.append("empty command")
+    else:
+        forbidden_shells = {"sh", "bash", "zsh", "fish", "cmd.exe", "powershell"}
+        if plan.command[0] in forbidden_shells:
+            violations.append(f"shell interpreters are not allowed: {plan.command[0]}")
+
+    if plan.repo_url and not plan.repo_url.startswith("https://"):
+        violations.append("non-HTTPS repo_url")
+
+    if plan.artifact_dir and ".." in plan.artifact_dir:
+        violations.append("path traversal in artifact path")
+
+    for key in plan.env:
+        upper_key = key.upper()
+        if any(s in upper_key for s in ["TOKEN", "SECRET", "PASSWORD", "KEY"]):
+            violations.append(f"environment variable name suggests secret: {key}")
+
+    if plan.image.endswith(":latest") or plan.image == "latest":
+        violations.append("image tag 'latest' is not allowed")
+
+    if plan.network_enabled and not plan.repo_url:
+        violations.append("network enabled without repo_url")
+
+    return violations

--- a/zakuro-poc-plugin/src/zakuro_poc/security/policy.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/security/policy.py
@@ -1,13 +1,24 @@
+from pathlib import PurePosixPath
+
+from zakuro_poc.config import ZakuroPocConfig
 from zakuro_poc.models import ExecutionPlan
 
 
-def validate_security_policy(plan: ExecutionPlan) -> list[str]:
+def _is_safe_relative_container_path(path: str) -> bool:
+    parsed_path = PurePosixPath(path)
+    return not parsed_path.is_absolute() and ".." not in parsed_path.parts
+
+
+def validate_security_policy(
+    plan: ExecutionPlan, config: ZakuroPocConfig | None = None
+) -> list[str]:
+    effective_config = config or ZakuroPocConfig()
     violations = []
     if not plan.command:
         violations.append("empty command")
     else:
         forbidden_shells = {"sh", "bash", "zsh", "fish", "cmd.exe", "powershell"}
-        if plan.command[0] in forbidden_shells:
+        if plan.command[0] in forbidden_shells and not effective_config.allow_shell:
             violations.append(f"shell interpreters are not allowed: {plan.command[0]}")
 
     if plan.repo_url and not plan.repo_url.startswith("https://"):
@@ -21,10 +32,36 @@ def validate_security_policy(plan: ExecutionPlan) -> list[str]:
         if any(s in upper_key for s in ["TOKEN", "SECRET", "PASSWORD", "KEY"]):
             violations.append(f"environment variable name suggests secret: {key}")
 
-    if plan.image.endswith(":latest") or plan.image == "latest":
+    if (plan.image.endswith(":latest") or plan.image == "latest") and not (
+        effective_config.allow_latest_images
+    ):
         violations.append("image tag 'latest' is not allowed")
+
+    if plan.network_enabled and not effective_config.allow_network:
+        violations.append("network requested but config does not allow network access")
 
     if plan.network_enabled and not plan.repo_url:
         violations.append("network enabled without repo_url")
+
+    if plan.resource_limits.timeout_seconds > effective_config.max_timeout_seconds:
+        violations.append(
+            "timeout exceeds configured maximum: "
+            f"{plan.resource_limits.timeout_seconds} > {effective_config.max_timeout_seconds}"
+        )
+
+    if plan.resource_limits.memory_mb > effective_config.max_memory_mb:
+        violations.append(
+            "memory exceeds configured maximum: "
+            f"{plan.resource_limits.memory_mb} > {effective_config.max_memory_mb}"
+        )
+
+    if plan.resource_limits.cpu_count > effective_config.max_cpu_count:
+        violations.append(
+            "CPU count exceeds configured maximum: "
+            f"{plan.resource_limits.cpu_count} > {effective_config.max_cpu_count}"
+        )
+
+    if plan.working_dir and not _is_safe_relative_container_path(plan.working_dir):
+        violations.append("working_dir must be a safe relative path under /workspace")
 
     return violations

--- a/zakuro-poc-plugin/src/zakuro_poc/validation.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/validation.py
@@ -1,0 +1,8 @@
+from zakuro_poc.models import ExecutionPlan
+from zakuro_poc.security.policy import validate_security_policy
+
+
+def validate_plan_or_raise(plan: ExecutionPlan) -> None:
+    violations = validate_security_policy(plan)
+    if violations:
+        raise ValueError("Security policy violations: " + ", ".join(violations))

--- a/zakuro-poc-plugin/src/zakuro_poc/validation.py
+++ b/zakuro-poc-plugin/src/zakuro_poc/validation.py
@@ -1,8 +1,13 @@
+from zakuro_poc.config import ZakuroPocConfig
 from zakuro_poc.models import ExecutionPlan
 from zakuro_poc.security.policy import validate_security_policy
 
 
-def validate_plan_or_raise(plan: ExecutionPlan) -> None:
-    violations = validate_security_policy(plan)
+def validate_plan(plan: ExecutionPlan, config: ZakuroPocConfig | None = None) -> list[str]:
+    return validate_security_policy(plan, config)
+
+
+def validate_plan_or_raise(plan: ExecutionPlan, config: ZakuroPocConfig | None = None) -> None:
+    violations = validate_plan(plan, config)
     if violations:
         raise ValueError("Security policy violations: " + ", ".join(violations))

--- a/zakuro-poc-plugin/tests/e2e/test_cli_demo.py
+++ b/zakuro-poc-plugin/tests/e2e/test_cli_demo.py
@@ -1,0 +1,85 @@
+import json
+
+from typer.testing import CliRunner
+
+from zakuro_poc.cli import app
+
+runner = CliRunner()
+
+
+def test_version_exits_0():
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "zakuro-poc-plugin" in result.stdout
+
+
+def test_validate_valid_plan_exits_0(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps({"job_name": "test", "image": "python:3.11", "command": ["ls"]})
+    )
+    result = runner.invoke(app, ["validate", "--plan", str(plan_path)])
+    assert result.exit_code == 0
+
+
+def test_validate_invalid_plan_exits_nonzero(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps({"job_name": "test", "image": "python:3.11", "command": ["bash", "-c", "ls"]})
+    )
+    result = runner.invoke(app, ["validate", "--plan", str(plan_path)])
+    assert result.exit_code == 1
+
+
+def test_plan_show_does_not_execute(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps({"job_name": "test", "image": "python:3.11", "command": ["ls"]})
+    )
+    result = runner.invoke(app, ["plan-show", "--plan", str(plan_path)])
+    assert result.exit_code == 0
+    assert "Job Name:" in result.stdout
+
+
+def test_execute_yes_with_noop_succeeds(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["ls"],
+            }
+        )
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"artifact_root": str(tmp_path)}))
+
+    result = runner.invoke(
+        app, ["execute", "--plan", str(plan_path), "--config", str(config_path), "--yes"]
+    )
+    assert result.exit_code == 0
+    assert "Status: succeeded" in result.stdout
+
+
+def test_execute_without_yes_aborts(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["ls"],
+            }
+        )
+    )
+    result = runner.invoke(app, ["execute", "--plan", str(plan_path)], input="no\n")
+    assert result.exit_code == 1
+    assert "Execution aborted" in result.stdout
+
+
+def test_doctor_returns_useful_output():
+    result = runner.invoke(app, ["doctor"])
+    assert "Python >= 3.11" in result.stdout

--- a/zakuro-poc-plugin/tests/e2e/test_cli_demo.py
+++ b/zakuro-poc-plugin/tests/e2e/test_cli_demo.py
@@ -1,16 +1,60 @@
+import builtins
+import importlib.metadata
 import json
+import runpy
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 from zakuro_poc.cli import app
+from zakuro_poc.models import ExecutionResult
 
 runner = CliRunner()
+
+
+def _result(
+    *,
+    status: str = "succeeded",
+    stderr: str = "",
+    stdout: str = "ok",
+) -> ExecutionResult:
+    now = datetime.now(UTC)
+    return ExecutionResult(
+        job_id="job-test",
+        job_name="test",
+        backend="noop",
+        status=status,  # type: ignore[arg-type]
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=0 if status == "succeeded" else 1 if status == "failed" else None,
+        duration_ms=1,
+        artifact_dir="/tmp/job-test",
+        started_at=now,
+        finished_at=now,
+        error_message=stderr or None,
+    )
 
 
 def test_version_exits_0():
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert "zakuro-poc-plugin" in result.stdout
+
+
+def test_version_reports_unknown_when_package_is_missing(monkeypatch):
+    def fake_version(_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+
+    result = runner.invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    assert "version unknown" in result.stdout
 
 
 def test_validate_valid_plan_exits_0(tmp_path):
@@ -29,6 +73,33 @@ def test_validate_invalid_plan_exits_nonzero(tmp_path):
     )
     result = runner.invoke(app, ["validate", "--plan", str(plan_path)])
     assert result.exit_code == 1
+
+
+def test_validate_missing_plan_fails_cleanly(tmp_path):
+    result = runner.invoke(app, ["validate", "--plan", str(tmp_path / "missing.json")])
+
+    assert result.exit_code == 1
+    assert "Plan file not found" in result.stdout
+
+
+def test_validate_invalid_json_fails_cleanly(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text("{ invalid json }")
+
+    result = runner.invoke(app, ["validate", "--plan", str(plan_path)])
+
+    assert result.exit_code == 1
+    assert "Invalid JSON in plan" in result.stdout
+
+
+def test_validate_schema_error_fails_cleanly(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps({"job_name": "test", "image": "python:3.11"}))
+
+    result = runner.invoke(app, ["validate", "--plan", str(plan_path)])
+
+    assert result.exit_code == 1
+    assert "does not match schema" in result.stdout
 
 
 def test_plan_show_does_not_execute(tmp_path):
@@ -63,6 +134,31 @@ def test_execute_yes_with_noop_succeeds(tmp_path):
     assert "Status: succeeded" in result.stdout
 
 
+def test_execute_prompts_and_accepts_yes(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["ls"],
+            }
+        )
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"artifact_root": str(tmp_path)}))
+
+    result = runner.invoke(
+        app,
+        ["execute", "--plan", str(plan_path), "--config", str(config_path)],
+        input="yes\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Type 'yes' to execute" in result.stdout
+
+
 def test_execute_without_yes_aborts(tmp_path):
     plan_path = tmp_path / "plan.json"
     plan_path.write_text(
@@ -78,6 +174,117 @@ def test_execute_without_yes_aborts(tmp_path):
     result = runner.invoke(app, ["execute", "--plan", str(plan_path)], input="no\n")
     assert result.exit_code == 1
     assert "Execution aborted" in result.stdout
+
+
+def test_execute_prints_json_output(monkeypatch, tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["ls"],
+            }
+        )
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"artifact_root": str(tmp_path)}))
+
+    monkeypatch.setattr("zakuro_poc.cli.execute_plan", lambda *_args, **_kwargs: _result())
+
+    result = runner.invoke(
+        app,
+        ["execute", "--plan", str(plan_path), "--config", str(config_path), "--yes", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert '"status": "succeeded"' in result.stdout
+
+
+def test_execute_prints_rejection_as_json(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["bash", "-c", "ls"],
+            }
+        )
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"artifact_root": str(tmp_path)}))
+
+    result = runner.invoke(
+        app,
+        ["execute", "--plan", str(plan_path), "--config", str(config_path), "--json"],
+    )
+
+    assert result.exit_code == 2
+    assert '"status": "rejected"' in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_exit"),
+    [("failed", 1), ("timed_out", 124), ("rejected", 2)],
+)
+def test_execute_maps_result_status_to_exit_codes(monkeypatch, tmp_path, status, expected_exit):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["ls"],
+            }
+        )
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"artifact_root": str(tmp_path)}))
+
+    monkeypatch.setattr(
+        "zakuro_poc.cli.execute_plan",
+        lambda *_args, **_kwargs: _result(status=status, stderr="details"),
+    )
+
+    result = runner.invoke(
+        app, ["execute", "--plan", str(plan_path), "--config", str(config_path), "--yes"]
+    )
+
+    assert result.exit_code == expected_exit
+    assert "details" in result.stdout
+
+
+def test_execute_prints_stderr_when_present(monkeypatch, tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["ls"],
+            }
+        )
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"artifact_root": str(tmp_path)}))
+
+    monkeypatch.setattr(
+        "zakuro_poc.cli.execute_plan",
+        lambda *_args, **_kwargs: _result(stderr="diagnostic", stdout="payload"),
+    )
+
+    result = runner.invoke(
+        app, ["execute", "--plan", str(plan_path), "--config", str(config_path), "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert "payload" in result.stdout
+    assert "diagnostic" in result.stdout
 
 
 def test_execute_rejects_invalid_plan_before_prompt(tmp_path):
@@ -106,3 +313,103 @@ def test_execute_rejects_invalid_plan_before_prompt(tmp_path):
 def test_doctor_returns_useful_output():
     result = runner.invoke(app, ["doctor"])
     assert "Python >= 3.11" in result.stdout
+
+
+def test_doctor_reports_all_ok(monkeypatch, tmp_path):
+    from zakuro_poc import cli
+
+    monkeypatch.setattr(cli.sys, "version_info", SimpleNamespace(major=3, minor=11))
+    monkeypatch.setattr(cli, "docker_available", lambda: True)
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        lambda _path=None: cli.ZakuroPocConfig(artifact_root=str(tmp_path)),
+    )
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "[OK] Docker CLI available" in result.stdout
+
+
+def test_doctor_reports_version_failure(monkeypatch):
+    from zakuro_poc import cli
+
+    monkeypatch.setattr(cli.sys, "version_info", SimpleNamespace(major=3, minor=10))
+    monkeypatch.setattr(cli, "load_config", lambda _path=None: cli.ZakuroPocConfig())
+    monkeypatch.setattr(cli, "docker_available", lambda: False)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Python >= 3.11" in result.stdout
+    assert "[FAIL]" in result.stdout
+
+
+def test_doctor_reports_import_failure(monkeypatch):
+    from zakuro_poc import cli
+
+    monkeypatch.setattr(cli.sys, "version_info", SimpleNamespace(major=3, minor=11))
+    monkeypatch.setattr(cli, "load_config", lambda _path=None: cli.ZakuroPocConfig())
+    monkeypatch.setattr(cli, "docker_available", lambda: False)
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: ANN001
+        if name == "zakuro_poc":
+            raise ImportError("boom")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Package import failed" in result.stdout
+
+
+def test_doctor_reports_config_load_failure(monkeypatch):
+    from zakuro_poc import cli
+
+    monkeypatch.setattr(cli.sys, "version_info", SimpleNamespace(major=3, minor=11))
+    monkeypatch.setattr(cli, "docker_available", lambda: False)
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        lambda _path=None: (_ for _ in ()).throw(RuntimeError("bad config")),
+    )
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Config load failed" in result.stdout
+
+
+def test_doctor_reports_artifact_root_failure(monkeypatch, tmp_path):
+    from zakuro_poc import cli
+
+    monkeypatch.setattr(cli.sys, "version_info", SimpleNamespace(major=3, minor=11))
+    monkeypatch.setattr(cli, "docker_available", lambda: False)
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        lambda _path=None: cli.ZakuroPocConfig(artifact_root=str(tmp_path)),
+    )
+
+    def fake_touch(*_args, **_kwargs):  # noqa: ANN001, ANN002
+        raise OSError("read-only")
+
+    monkeypatch.setattr(Path, "touch", fake_touch)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Artifact root not writable" in result.stdout
+
+
+def test_main_module_entrypoint_executes(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["zakuro-poc-plugin", "version"])
+    try:
+        runpy.run_module("zakuro_poc.__main__", run_name="__main__")
+    except SystemExit as exc:
+        assert exc.code in (0, None)

--- a/zakuro-poc-plugin/tests/e2e/test_cli_demo.py
+++ b/zakuro-poc-plugin/tests/e2e/test_cli_demo.py
@@ -80,6 +80,29 @@ def test_execute_without_yes_aborts(tmp_path):
     assert "Execution aborted" in result.stdout
 
 
+def test_execute_rejects_invalid_plan_before_prompt(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "job_name": "test",
+                "backend": "noop",
+                "image": "python:3.11",
+                "command": ["bash", "-c", "ls"],
+            }
+        )
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"artifact_root": str(tmp_path)}))
+
+    result = runner.invoke(app, ["execute", "--plan", str(plan_path), "--config", str(config_path)])
+
+    assert result.exit_code == 2
+    assert "Validation rejected" in result.stdout
+    assert "Type 'yes' to execute" not in result.stdout
+    assert "Status: rejected" in result.stdout
+
+
 def test_doctor_returns_useful_output():
     result = runner.invoke(app, ["doctor"])
     assert "Python >= 3.11" in result.stdout

--- a/zakuro-poc-plugin/tests/integration/test_docker_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_docker_backend.py
@@ -1,0 +1,145 @@
+import pytest
+
+from zakuro_poc.backends.docker_backend import DockerBackend, build_docker_command
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.artifacts import create_artifact_dir
+from zakuro_poc.execution.ids import new_job_id
+from zakuro_poc.models import ExecutionPlan
+
+
+@pytest.mark.docker
+def test_docker_simple_python_command_succeeds(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello from docker')"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = DockerBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert result.status == "succeeded"
+    assert result.exit_code == 0
+    assert "hello from docker" in result.stdout
+
+
+@pytest.mark.docker
+def test_docker_command_returning_nonzero_fails(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker-fail",
+        image="python:3.11-slim",
+        command=[
+            "python",
+            "-c",
+            "import sys; print('error output', file=sys.stderr); sys.exit(42)",
+        ],
+    )
+    config = ZakuroPocConfig()
+
+    backend = DockerBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert result.status == "failed"
+    assert result.exit_code == 42
+    assert "error output" in result.stderr
+
+
+@pytest.mark.docker
+def test_docker_timeout_produces_timed_out(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker-timeout",
+        image="python:3.11-slim",
+        command=["python", "-c", "import time; time.sleep(10)"],
+    )
+    plan.resource_limits.timeout_seconds = 1
+    config = ZakuroPocConfig()
+
+    backend = DockerBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert result.status == "timed_out"
+    assert result.exit_code is None
+    assert "Job timed out after" in result.stderr
+
+
+def test_docker_command_does_not_use_shell(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+    )
+    config = ZakuroPocConfig()
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+    assert not any("shell=True" in str(arg) for arg in cmd)
+
+
+def test_network_defaults_to_none(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+    )
+    config = ZakuroPocConfig()
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+    assert "--network" in cmd
+    idx = cmd.index("--network")
+    assert cmd[idx + 1] == "none"
+
+
+def test_memory_and_cpu_flags_are_present(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+    )
+    plan.resource_limits.cpu_count = 2.5
+    plan.resource_limits.memory_mb = 1024
+    config = ZakuroPocConfig()
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+
+    assert "--cpus" in cmd
+    cpu_idx = cmd.index("--cpus")
+    assert cmd[cpu_idx + 1] == "2.5"
+
+    assert "--memory" in cmd
+    mem_idx = cmd.index("--memory")
+    assert cmd[mem_idx + 1] == "1024m"
+
+
+@pytest.mark.docker
+def test_docker_artifact_files_created(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker-artifacts",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = DockerBackend()
+    backend.run(plan, artifact_dir, config)
+
+    assert (artifact_dir / "stdout.txt").exists()
+    assert (artifact_dir / "stderr.txt").exists()
+    assert (artifact_dir / "result.json").exists()
+    assert (artifact_dir / "metadata.json").exists()
+    assert (artifact_dir / "plan.json").exists()
+    assert (artifact_dir / "workspace").exists()
+    assert (artifact_dir / "workspace").is_dir()

--- a/zakuro-poc-plugin/tests/integration/test_docker_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_docker_backend.py
@@ -122,6 +122,79 @@ def test_memory_and_cpu_flags_are_present(tmp_path):
     assert cmd[mem_idx + 1] == "1024m"
 
 
+def test_docker_command_uses_hardening_flags(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+    )
+    config = ZakuroPocConfig()
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+
+    assert "--security-opt" in cmd
+    assert "no-new-privileges" in cmd
+    assert "--cap-drop" in cmd
+    assert "ALL" in cmd
+    assert "--pids-limit" in cmd
+
+
+def test_docker_command_honours_env_and_working_dir(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+        env={"SAKURA_MODE": "test"},
+        working_dir="repo",
+    )
+    config = ZakuroPocConfig()
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+
+    assert "--env" in cmd
+    assert "SAKURA_MODE=test" in cmd
+    workdir_idx = cmd.index("-w")
+    assert cmd[workdir_idx + 1] == "/workspace/repo"
+
+
+def test_read_only_root_flag_is_configurable(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+    )
+    config = ZakuroPocConfig(docker={"read_only_root": True})
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+
+    assert "--read-only" in cmd
+    assert "--tmpfs" in cmd
+
+
+def test_network_mode_uses_config_when_network_is_allowed(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+        repo_url="https://github.com/octocat/Hello-World.git",
+        network_enabled=True,
+    )
+    config = ZakuroPocConfig(allow_network=True, docker={"network_mode": "bridge"})
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+
+    network_idx = cmd.index("--network")
+    assert cmd[network_idx + 1] == "bridge"
+
+
 @pytest.mark.docker
 def test_docker_artifact_files_created(tmp_path):
     job_id = new_job_id()

--- a/zakuro-poc-plugin/tests/integration/test_docker_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_docker_backend.py
@@ -139,6 +139,25 @@ def test_docker_command_uses_hardening_flags(tmp_path):
     assert "--cap-drop" in cmd
     assert "ALL" in cmd
     assert "--pids-limit" in cmd
+    assert "--user" in cmd
+    user_idx = cmd.index("--user")
+    assert cmd[user_idx + 1] == "65532:65532"
+
+
+def test_docker_user_is_configurable(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker",
+        image="python:3.11-slim",
+        command=["python", "-c", "print('hello')"],
+    )
+    config = ZakuroPocConfig(docker={"user": "1000:1000"})
+
+    cmd = build_docker_command(plan, artifact_dir, config)
+
+    user_idx = cmd.index("--user")
+    assert cmd[user_idx + 1] == "1000:1000"
 
 
 def test_docker_command_honours_env_and_working_dir(tmp_path):
@@ -216,3 +235,21 @@ def test_docker_artifact_files_created(tmp_path):
     assert (artifact_dir / "plan.json").exists()
     assert (artifact_dir / "workspace").exists()
     assert (artifact_dir / "workspace").is_dir()
+
+
+@pytest.mark.docker
+def test_docker_non_root_user_can_write_workspace(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-docker-non-root-write",
+        image="python:3.11-slim",
+        command=["python", "-c", "open('/workspace/non-root.txt', 'w').write('ok')"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = DockerBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert result.status == "succeeded"
+    assert (artifact_dir / "workspace" / "non-root.txt").read_text(encoding="utf-8") == "ok"

--- a/zakuro-poc-plugin/tests/integration/test_docker_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_docker_backend.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import pytest
 
 from zakuro_poc.backends.docker_backend import DockerBackend, build_docker_command
@@ -144,6 +146,17 @@ def test_docker_command_uses_hardening_flags(tmp_path):
     assert cmd[user_idx + 1] == "65532:65532"
 
 
+def test_docker_available_returns_false_when_cli_is_missing(monkeypatch):
+    from zakuro_poc.backends import docker_backend
+
+    def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert docker_backend.docker_available() is False
+
+
 def test_docker_user_is_configurable(tmp_path):
     job_id = new_job_id()
     artifact_dir = create_artifact_dir(tmp_path, job_id)
@@ -212,6 +225,42 @@ def test_network_mode_uses_config_when_network_is_allowed(tmp_path):
 
     network_idx = cmd.index("--network")
     assert cmd[network_idx + 1] == "bridge"
+
+
+def test_docker_backend_reports_unavailable_docker(tmp_path, monkeypatch):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-docker-missing", image="python:3.11-slim", command=["ls"])
+    config = ZakuroPocConfig()
+
+    monkeypatch.setattr("zakuro_poc.backends.docker_backend.docker_available", lambda: False)
+
+    result = DockerBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "failed"
+    assert result.exit_code is None
+    assert "Docker is not available" in result.stderr
+    assert (artifact_dir / "result.json").exists()
+
+
+def test_docker_backend_normalises_unexpected_errors(tmp_path, monkeypatch):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-docker-error", image="python:3.11-slim", command=["ls"])
+    config = ZakuroPocConfig()
+
+    monkeypatch.setattr("zakuro_poc.backends.docker_backend.docker_available", lambda: True)
+
+    def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = DockerBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "failed"
+    assert "Failed to execute docker command" in result.stderr
+    assert result.error_message == "boom"
 
 
 @pytest.mark.docker

--- a/zakuro-poc-plugin/tests/integration/test_noop_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_noop_backend.py
@@ -1,0 +1,93 @@
+import json
+
+from zakuro_poc.backends.noop_backend import NoopBackend
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.artifacts import create_artifact_dir
+from zakuro_poc.execution.ids import new_job_id
+from zakuro_poc.models import ExecutionPlan
+
+
+def test_noop_backend_returns_success(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-noop",
+        command=["echo", "hello"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = NoopBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert result.status == "succeeded"
+    assert result.exit_code == 0
+    assert result.backend == "noop"
+
+
+def test_noop_backend_writes_stdout(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-noop",
+        command=["echo", "hello"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = NoopBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert "NoopBackend: Executing plan test-noop" in result.stdout
+    assert "echo" in result.stdout
+
+    stdout_file = artifact_dir / "stdout.txt"
+    assert stdout_file.read_text(encoding="utf-8") == result.stdout
+
+
+def test_noop_backend_preserves_job_name(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="specific-job-name",
+        command=["echo", "hello"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = NoopBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert result.job_name == "specific-job-name"
+
+
+def test_noop_backend_returns_duration(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-noop",
+        command=["echo", "hello"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = NoopBackend()
+    result = backend.run(plan, artifact_dir, config)
+
+    assert result.duration_ms >= 0
+
+
+def test_noop_backend_creates_result_artifact(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-noop",
+        command=["echo", "hello"],
+    )
+    config = ZakuroPocConfig()
+
+    backend = NoopBackend()
+    backend.run(plan, artifact_dir, config)
+
+    result_file = artifact_dir / "result.json"
+    assert result_file.exists()
+
+    data = json.loads(result_file.read_text(encoding="utf-8"))
+    assert data["job_name"] == "test-noop"
+    assert data["status"] == "succeeded"

--- a/zakuro-poc-plugin/tests/integration/test_runner.py
+++ b/zakuro-poc-plugin/tests/integration/test_runner.py
@@ -24,8 +24,13 @@ def test_invalid_plan_rejected_by_policy(tmp_path):
     config = ZakuroPocConfig(artifact_root=str(tmp_path))
     # This plan uses bash, which is rejected by security policy
     plan = ExecutionPlan(job_name="test", backend="noop", command=["bash", "-c", "ls"])
-    with pytest.raises(ValueError, match="Security policy violations"):
-        execute_plan(plan, config)
+    result = execute_plan(plan, config)
+
+    assert result.status == "rejected"
+    assert result.exit_code is None
+    assert "Security policy violations" in (result.error_message or "")
+    assert (tmp_path / result.job_id / "result.json").exists()
+    assert (tmp_path / result.job_id / "stderr.txt").exists()
 
 
 def test_unknown_backend_rejected(tmp_path):
@@ -33,8 +38,10 @@ def test_unknown_backend_rejected(tmp_path):
     plan = ExecutionPlan(job_name="test", command=["ls"])
     # Bypass pydantic validation for testing the runner's exception
     plan.backend = "unknown"
-    with pytest.raises(ValueError, match="Unknown backend: unknown"):
-        execute_plan(plan, config)
+    result = execute_plan(plan, config)
+
+    assert result.status == "rejected"
+    assert result.error_message == "Unknown backend: unknown"
 
 
 def test_artifacts_are_written(tmp_path):
@@ -45,6 +52,10 @@ def test_artifacts_are_written(tmp_path):
     artifact_dir = tmp_path / result.job_id
     assert (artifact_dir / "plan.json").exists()
     assert (artifact_dir / "result.json").exists()
+    assert (artifact_dir / "stdout.txt").exists()
+    assert (artifact_dir / "stderr.txt").exists()
+    assert (artifact_dir / "metadata.json").exists()
+    assert (artifact_dir / "workspace").is_dir()
 
 
 def test_result_contains_job_id(tmp_path):

--- a/zakuro-poc-plugin/tests/integration/test_runner.py
+++ b/zakuro-poc-plugin/tests/integration/test_runner.py
@@ -1,8 +1,9 @@
 import pytest
 from pydantic import ValidationError
 
+from zakuro_poc.backends.docker_backend import DockerBackend
 from zakuro_poc.config import ZakuroPocConfig
-from zakuro_poc.execution.runner import execute_plan
+from zakuro_poc.execution.runner import default_backend_factory, execute_plan
 from zakuro_poc.models import ExecutionPlan
 
 
@@ -70,3 +71,8 @@ def test_duration_is_non_negative(tmp_path):
     plan = ExecutionPlan(job_name="test", backend="noop", command=["ls"])
     result = execute_plan(plan, config)
     assert result.duration_ms >= 0
+
+
+def test_default_backend_factory_returns_docker_backend():
+    backend = default_backend_factory("docker")
+    assert isinstance(backend, DockerBackend)

--- a/zakuro-poc-plugin/tests/integration/test_runner.py
+++ b/zakuro-poc-plugin/tests/integration/test_runner.py
@@ -1,0 +1,61 @@
+import pytest
+from pydantic import ValidationError
+
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.runner import execute_plan
+from zakuro_poc.models import ExecutionPlan
+
+
+def test_noop_plan_executes(tmp_path):
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(job_name="test", backend="noop", command=["ls"])
+    result = execute_plan(plan, config)
+    assert result.status == "succeeded"
+
+
+def test_invalid_plan_rejected(tmp_path):
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))  # noqa: F841
+    # This plan has an empty command, which is rejected by Pydantic
+    with pytest.raises(ValidationError):
+        ExecutionPlan(job_name="test", backend="noop", command=[])
+
+
+def test_invalid_plan_rejected_by_policy(tmp_path):
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    # This plan uses bash, which is rejected by security policy
+    plan = ExecutionPlan(job_name="test", backend="noop", command=["bash", "-c", "ls"])
+    with pytest.raises(ValueError, match="Security policy violations"):
+        execute_plan(plan, config)
+
+
+def test_unknown_backend_rejected(tmp_path):
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(job_name="test", command=["ls"])
+    # Bypass pydantic validation for testing the runner's exception
+    plan.backend = "unknown"
+    with pytest.raises(ValueError, match="Unknown backend: unknown"):
+        execute_plan(plan, config)
+
+
+def test_artifacts_are_written(tmp_path):
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(job_name="test", backend="noop", command=["ls"])
+    result = execute_plan(plan, config)
+
+    artifact_dir = tmp_path / result.job_id
+    assert (artifact_dir / "plan.json").exists()
+    assert (artifact_dir / "result.json").exists()
+
+
+def test_result_contains_job_id(tmp_path):
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(job_name="test", backend="noop", command=["ls"])
+    result = execute_plan(plan, config)
+    assert result.job_id.startswith("job-")
+
+
+def test_duration_is_non_negative(tmp_path):
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(job_name="test", backend="noop", command=["ls"])
+    result = execute_plan(plan, config)
+    assert result.duration_ms >= 0

--- a/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
@@ -1,0 +1,106 @@
+import subprocess
+
+from zakuro_poc.backends.zakuro_backend import ZakuroBackend, build_zakuro_command
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.artifacts import create_artifact_dir, write_text_artifact
+from zakuro_poc.execution.ids import new_job_id
+from zakuro_poc.models import ExecutionPlan
+
+
+def test_build_zakuro_command_uses_configured_contract(tmp_path):
+    plan_file = tmp_path / "plan.json"
+    config = ZakuroPocConfig(
+        zakuro={
+            "executable": "zc-dev",
+            "execute_args": ["execute", "--local"],
+            "plan_arg": "--plan-file",
+            "json_arg": "--output-json",
+        }
+    )
+
+    command = build_zakuro_command(plan_file, config)
+
+    assert command == [
+        "zc-dev",
+        "execute",
+        "--local",
+        "--plan-file",
+        str(plan_file),
+        "--output-json",
+    ]
+
+
+def test_zakuro_backend_reports_missing_executable(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-zakuro", backend="zakuro", command=["echo", "hello"])
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    config = ZakuroPocConfig(zakuro={"executable": "definitely-missing-zc"})
+
+    result = ZakuroBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "failed"
+    assert result.exit_code is None
+    assert "Zakuro executable not found" in result.stderr
+
+
+def test_zakuro_backend_normalises_subprocess_success(monkeypatch, tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-zakuro", backend="zakuro", command=["echo", "hello"])
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    config = ZakuroPocConfig()
+
+    def fake_run(*args, **_kwargs):  # noqa: ANN001, ANN202
+        return subprocess.CompletedProcess(
+            args=args[0], returncode=0, stdout='{"ok": true}', stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ZakuroBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "succeeded"
+    assert result.exit_code == 0
+    assert result.stdout == '{"ok": true}'
+    assert result.backend == "zakuro"
+
+
+def test_zakuro_backend_normalises_timeout(monkeypatch, tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(
+        job_name="test-zakuro-timeout", backend="zakuro", command=["echo", "hello"]
+    )
+    plan.resource_limits.timeout_seconds = 1
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    config = ZakuroPocConfig()
+
+    def fake_run(*args, **_kwargs):  # noqa: ANN001, ANN202
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=1, output="partial", stderr="late")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ZakuroBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "timed_out"
+    assert result.exit_code is None
+    assert result.stdout == "partial"
+    assert "Zakuro execution timed out" in result.stderr
+
+
+def test_real_zakuro_backend_is_selected_by_runner(tmp_path):
+    from zakuro_poc.execution.runner import execute_plan
+
+    config = ZakuroPocConfig(
+        artifact_root=str(tmp_path),
+        zakuro={"executable": "definitely-missing-zc"},
+    )
+    plan = ExecutionPlan(job_name="test-zakuro-runner", backend="zakuro", command=["echo", "hello"])
+
+    result = execute_plan(plan, config)
+
+    assert result.backend == "zakuro"
+    assert result.status == "failed"
+    assert "Zakuro executable not found" in result.stderr
+    assert (tmp_path / result.job_id / "result.json").exists()

--- a/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
@@ -130,12 +130,16 @@ def test_zakuro_backend_reports_unexpected_exception(monkeypatch, tmp_path):
 def test_zakuro_backend_reports_segmentation_fault(monkeypatch, tmp_path):
     job_id = new_job_id()
     artifact_dir = create_artifact_dir(tmp_path, job_id)
-    plan = ExecutionPlan(job_name="test-zakuro-segfault", backend="zakuro", command=["echo", "hello"])
+    plan = ExecutionPlan(
+        job_name="test-zakuro-segfault", backend="zakuro", command=["echo", "hello"]
+    )
     write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
     config = ZakuroPocConfig()
 
     def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
-        return subprocess.CompletedProcess(args=["zc"], returncode=-11, stdout="", stderr="Segmentation fault (core dumped)")
+        return subprocess.CompletedProcess(
+            args=["zc"], returncode=-11, stdout="", stderr="Segmentation fault (core dumped)"
+        )
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -150,12 +154,16 @@ def test_zakuro_backend_reports_segmentation_fault(monkeypatch, tmp_path):
 def test_zakuro_backend_handles_malformed_json_output(monkeypatch, tmp_path):
     job_id = new_job_id()
     artifact_dir = create_artifact_dir(tmp_path, job_id)
-    plan = ExecutionPlan(job_name="test-zakuro-badjson", backend="zakuro", command=["echo", "hello"])
+    plan = ExecutionPlan(
+        job_name="test-zakuro-badjson", backend="zakuro", command=["echo", "hello"]
+    )
     write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
     config = ZakuroPocConfig()
 
     def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
-        return subprocess.CompletedProcess(args=["zc"], returncode=0, stdout='{"incomplete": true', stderr="")
+        return subprocess.CompletedProcess(
+            args=["zc"], returncode=0, stdout='{"incomplete": true', stderr=""
+        )
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -165,6 +173,7 @@ def test_zakuro_backend_handles_malformed_json_output(monkeypatch, tmp_path):
     assert result.status == "succeeded"
     assert result.stdout == '{"incomplete": true'
     assert result.exit_code == 0
+
 
 def test_real_zakuro_backend_is_selected_by_runner(tmp_path):
     from zakuro_poc.execution.runner import execute_plan

--- a/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
@@ -127,6 +127,45 @@ def test_zakuro_backend_reports_unexpected_exception(monkeypatch, tmp_path):
     assert result.error_message == "kaboom"
 
 
+def test_zakuro_backend_reports_segmentation_fault(monkeypatch, tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-zakuro-segfault", backend="zakuro", command=["echo", "hello"])
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    config = ZakuroPocConfig()
+
+    def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
+        return subprocess.CompletedProcess(args=["zc"], returncode=-11, stdout="", stderr="Segmentation fault (core dumped)")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ZakuroBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "failed"
+    assert result.exit_code == -11
+    assert result.error_message == "zc execute returned a non-zero exit code"
+    assert "Segmentation fault" in result.stderr
+
+
+def test_zakuro_backend_handles_malformed_json_output(monkeypatch, tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-zakuro-badjson", backend="zakuro", command=["echo", "hello"])
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    config = ZakuroPocConfig()
+
+    def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
+        return subprocess.CompletedProcess(args=["zc"], returncode=0, stdout='{"incomplete": true', stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ZakuroBackend().run(plan, artifact_dir, config)
+
+    # Currently it just passes through stdout without parsing it
+    assert result.status == "succeeded"
+    assert result.stdout == '{"incomplete": true'
+    assert result.exit_code == 0
+
 def test_real_zakuro_backend_is_selected_by_runner(tmp_path):
     from zakuro_poc.execution.runner import execute_plan
 

--- a/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
+++ b/zakuro-poc-plugin/tests/integration/test_zakuro_backend.py
@@ -89,6 +89,44 @@ def test_zakuro_backend_normalises_timeout(monkeypatch, tmp_path):
     assert "Zakuro execution timed out" in result.stderr
 
 
+def test_zakuro_backend_reports_non_zero_exit(monkeypatch, tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-zakuro-fail", backend="zakuro", command=["echo", "hello"])
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    config = ZakuroPocConfig()
+
+    def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
+        return subprocess.CompletedProcess(args=["zc"], returncode=7, stdout="", stderr="oops")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ZakuroBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "failed"
+    assert result.exit_code == 7
+    assert result.error_message == "zc execute returned a non-zero exit code"
+
+
+def test_zakuro_backend_reports_unexpected_exception(monkeypatch, tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    plan = ExecutionPlan(job_name="test-zakuro-error", backend="zakuro", command=["echo", "hello"])
+    write_text_artifact(artifact_dir, "plan.json", plan.model_dump_json(indent=2))
+    config = ZakuroPocConfig()
+
+    def fake_run(*_args, **_kwargs):  # noqa: ANN001, ANN202
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ZakuroBackend().run(plan, artifact_dir, config)
+
+    assert result.status == "failed"
+    assert "Failed to execute Zakuro command" in result.stderr
+    assert result.error_message == "kaboom"
+
+
 def test_real_zakuro_backend_is_selected_by_runner(tmp_path):
     from zakuro_poc.execution.runner import execute_plan
 

--- a/zakuro-poc-plugin/tests/integration/test_zakuro_backend_contract.py
+++ b/zakuro-poc-plugin/tests/integration/test_zakuro_backend_contract.py
@@ -1,0 +1,112 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+from zakuro_poc.backends.base import ExecutionBackend
+from zakuro_poc.config import ZakuroPocConfig
+from zakuro_poc.execution.runner import execute_plan
+from zakuro_poc.models import ExecutionPlan, ExecutionResult
+
+
+class FakeZakuroBackend(ExecutionBackend):
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.was_called = False
+        self.plan_file_existed_before_run = False
+
+    def run(
+        self,
+        plan: ExecutionPlan,
+        artifact_dir: Path,
+        config: ZakuroPocConfig,  # noqa: ARG002
+    ) -> ExecutionResult:
+        self.was_called = True
+        self.plan_file_existed_before_run = (artifact_dir / "plan.json").exists()
+        started_at = datetime.now(UTC)
+        finished_at = datetime.now(UTC)
+        if self.fail:
+            return ExecutionResult(
+                job_id=artifact_dir.name,
+                job_name=plan.job_name,
+                backend="zakuro",
+                status="failed",
+                stdout="",
+                stderr="fake zakuro failure",
+                exit_code=17,
+                duration_ms=0,
+                artifact_dir=str(artifact_dir),
+                started_at=started_at,
+                finished_at=finished_at,
+                error_message="fake zakuro failure",
+            )
+
+        return ExecutionResult(
+            job_id=artifact_dir.name,
+            job_name=plan.job_name,
+            backend="zakuro",
+            status="succeeded",
+            stdout="fake zakuro success",
+            stderr="",
+            exit_code=0,
+            duration_ms=0,
+            artifact_dir=str(artifact_dir),
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+
+def test_fake_zakuro_backend_preserves_runner_contract(tmp_path):
+    backend = FakeZakuroBackend()
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(job_name="zakuro-contract", backend="zakuro", command=["echo", "hello"])
+
+    result = execute_plan(
+        plan, config, backend_factory=lambda name: backend if name == "zakuro" else None
+    )
+
+    artifact_dir = tmp_path / result.job_id
+    assert backend.was_called
+    assert backend.plan_file_existed_before_run
+    assert result.status == "succeeded"
+    assert result.backend == "zakuro"
+    assert result.stdout == "fake zakuro success"
+    assert (artifact_dir / "plan.json").exists()
+    assert (artifact_dir / "result.json").exists()
+    assert (artifact_dir / "stdout.txt").read_text(encoding="utf-8") == "fake zakuro success"
+    assert (artifact_dir / "stderr.txt").read_text(encoding="utf-8") == ""
+    assert (artifact_dir / "metadata.json").exists()
+    assert (artifact_dir / "workspace").is_dir()
+
+
+def test_fake_zakuro_backend_failure_is_normalised(tmp_path):
+    backend = FakeZakuroBackend(fail=True)
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(
+        job_name="zakuro-contract-fail", backend="zakuro", command=["echo", "hello"]
+    )
+
+    result = execute_plan(
+        plan, config, backend_factory=lambda name: backend if name == "zakuro" else None
+    )
+
+    artifact_dir = tmp_path / result.job_id
+    assert backend.was_called
+    assert result.status == "failed"
+    assert result.exit_code == 17
+    assert result.error_message == "fake zakuro failure"
+    assert (artifact_dir / "stderr.txt").read_text(encoding="utf-8") == "fake zakuro failure"
+
+
+def test_invalid_zakuro_plan_is_rejected_before_backend_call(tmp_path):
+    backend = FakeZakuroBackend()
+    config = ZakuroPocConfig(artifact_root=str(tmp_path))
+    plan = ExecutionPlan(
+        job_name="zakuro-contract-reject", backend="zakuro", command=["bash", "-c", "ls"]
+    )
+
+    result = execute_plan(
+        plan, config, backend_factory=lambda name: backend if name == "zakuro" else None
+    )
+
+    assert not backend.was_called
+    assert result.status == "rejected"
+    assert "Security policy violations" in (result.error_message or "")

--- a/zakuro-poc-plugin/tests/unit/test_artifacts.py
+++ b/zakuro-poc-plugin/tests/unit/test_artifacts.py
@@ -1,0 +1,36 @@
+import pytest
+
+from zakuro_poc.execution.artifacts import create_artifact_dir, write_text_artifact
+from zakuro_poc.execution.ids import new_job_id
+
+
+def test_creates_job_directory(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    assert artifact_dir.exists()
+    assert artifact_dir.is_dir()
+    assert artifact_dir.name == job_id
+
+
+def test_writes_stdout_artifact(tmp_path):
+    job_id = new_job_id()
+    artifact_dir = create_artifact_dir(tmp_path, job_id)
+    file_path = write_text_artifact(artifact_dir, "stdout.txt", "hello world")
+    assert file_path.exists()
+    assert file_path.read_text(encoding="utf-8") == "hello world"
+
+
+def test_rejects_unsafe_job_id_containing_slash(tmp_path):
+    with pytest.raises(ValueError, match="Unsafe job ID"):
+        create_artifact_dir(tmp_path, "job/123")
+
+
+def test_rejects_path_traversal(tmp_path):
+    with pytest.raises(ValueError, match="Invalid artifact name"):
+        write_text_artifact(tmp_path, "../outside.txt", "data")
+
+
+def test_does_not_overwrite_outside_root(tmp_path):
+    # Testing that write_text_artifact safely rejects malicious paths
+    with pytest.raises(ValueError, match="Invalid artifact name"):
+        write_text_artifact(tmp_path, "../../etc/passwd", "data")

--- a/zakuro-poc-plugin/tests/unit/test_config.py
+++ b/zakuro-poc-plugin/tests/unit/test_config.py
@@ -1,0 +1,46 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from zakuro_poc.config import ZakuroPocConfig, load_config
+
+
+def test_built_in_defaults_load(monkeypatch, tmp_path):
+    # Ensure no config files are found
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    config = load_config()
+    assert config.artifact_root == "./zakuro-artifacts"
+    assert config.max_timeout_seconds == 3600
+
+
+def test_explicit_config_path_loads(tmp_path):
+    config_path = tmp_path / "custom.json"
+    config_path.write_text(
+        json.dumps({"artifact_root": "/custom/path", "max_timeout_seconds": 120})
+    )
+
+    config = load_config(str(config_path))
+    assert config.artifact_root == "/custom/path"
+    assert config.max_timeout_seconds == 120
+
+
+def test_invalid_json_fails_clearly(tmp_path):
+    config_path = tmp_path / "invalid.json"
+    config_path.write_text("{ invalid json }")
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        load_config(str(config_path))
+
+
+def test_invalid_docker_network_mode_rejected():
+    with pytest.raises(ValidationError):
+        ZakuroPocConfig(docker={"network_mode": "host"})
+
+
+def test_missing_config_falls_back_safely(tmp_path):
+    missing_path = tmp_path / "does_not_exist.json"
+    config = load_config(str(missing_path))
+    assert config.artifact_root == "./zakuro-artifacts"

--- a/zakuro-poc-plugin/tests/unit/test_config.py
+++ b/zakuro-poc-plugin/tests/unit/test_config.py
@@ -40,6 +40,19 @@ def test_invalid_docker_network_mode_rejected():
         ZakuroPocConfig(docker={"network_mode": "host"})
 
 
+def test_docker_non_root_user_is_default():
+    config = ZakuroPocConfig()
+    assert config.docker.user == "65532:65532"
+
+
+def test_zakuro_backend_defaults_to_zc_execute():
+    config = ZakuroPocConfig()
+    assert config.zakuro.executable == "zc"
+    assert config.zakuro.execute_args == ["execute"]
+    assert config.zakuro.plan_arg == "--plan"
+    assert config.zakuro.json_arg == "--json"
+
+
 def test_missing_config_falls_back_safely(tmp_path):
     missing_path = tmp_path / "does_not_exist.json"
     config = load_config(str(missing_path))

--- a/zakuro-poc-plugin/tests/unit/test_logging.py
+++ b/zakuro-poc-plugin/tests/unit/test_logging.py
@@ -1,0 +1,30 @@
+import logging
+
+from zakuro_poc.observability.logging import configure_logging
+
+
+def test_configure_logging_sets_debug_level(monkeypatch):
+    recorded = {}
+
+    def fake_basic_config(**kwargs):  # noqa: ANN003
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+
+    configure_logging(verbose=True)
+
+    assert recorded["level"] == logging.DEBUG
+    assert recorded["datefmt"] == "%Y-%m-%d %H:%M:%S"
+
+
+def test_configure_logging_sets_info_level(monkeypatch):
+    recorded = {}
+
+    def fake_basic_config(**kwargs):  # noqa: ANN003
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+
+    configure_logging(verbose=False)
+
+    assert recorded["level"] == logging.INFO

--- a/zakuro-poc-plugin/tests/unit/test_models.py
+++ b/zakuro-poc-plugin/tests/unit/test_models.py
@@ -14,6 +14,11 @@ def test_valid_minimal_plan():
     assert plan.backend == "docker"
 
 
+def test_zakuro_backend_plan_is_valid():
+    plan = ExecutionPlan(job_name="test-zakuro", backend="zakuro", command=["echo", "hello"])
+    assert plan.backend == "zakuro"
+
+
 def test_empty_command_rejected():
     with pytest.raises(ValidationError):
         ExecutionPlan(job_name="test", image="python:3.11", command=[])

--- a/zakuro-poc-plugin/tests/unit/test_models.py
+++ b/zakuro-poc-plugin/tests/unit/test_models.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from zakuro_poc.models import ExecutionPlan, ResourceLimits
+
+
+def test_valid_minimal_plan():
+    plan = ExecutionPlan(
+        job_name="test-job", image="python:3.11", command=["python", "-c", "print('hello')"]
+    )
+    assert plan.job_name == "test-job"
+    assert plan.image == "python:3.11"
+    assert plan.command == ["python", "-c", "print('hello')"]
+    assert plan.backend == "docker"
+
+
+def test_empty_command_rejected():
+    with pytest.raises(ValidationError):
+        ExecutionPlan(job_name="test", image="python:3.11", command=[])
+
+
+def test_empty_image_rejected():
+    with pytest.raises(ValidationError):
+        ExecutionPlan(job_name="test", image="", command=["ls"])
+
+
+def test_invalid_cpu_rejected():
+    with pytest.raises(ValidationError):
+        ResourceLimits(cpu_count=0.0)
+    with pytest.raises(ValidationError):
+        ResourceLimits(cpu_count=-1.0)
+
+
+def test_memory_below_minimum_rejected():
+    with pytest.raises(ValidationError):
+        ResourceLimits(memory_mb=127)
+
+
+def test_timeout_above_maximum_rejected():
+    with pytest.raises(ValidationError):
+        ResourceLimits(timeout_seconds=3601)
+
+
+def test_gpu_negative_rejected():
+    with pytest.raises(ValidationError):
+        ResourceLimits(gpu_count=-1)
+
+
+def test_env_var_invalid_name_rejected():
+    with pytest.raises(ValidationError):
+        ExecutionPlan(job_name="test", command=["ls"], env={"1INVALID": "value"})
+
+
+def test_https_repo_url_accepted():
+    plan = ExecutionPlan(
+        job_name="test", command=["ls"], repo_url="https://github.com/octocat/Hello-World.git"
+    )
+    assert plan.repo_url == "https://github.com/octocat/Hello-World.git"
+
+
+def test_non_https_repo_url_rejected():
+    with pytest.raises(ValidationError):
+        ExecutionPlan(
+            job_name="test", command=["ls"], repo_url="git@github.com:octocat/Hello-World.git"
+        )
+    with pytest.raises(ValidationError):
+        ExecutionPlan(
+            job_name="test", command=["ls"], repo_url="http://github.com/octocat/Hello-World.git"
+        )

--- a/zakuro-poc-plugin/tests/unit/test_security_policy.py
+++ b/zakuro-poc-plugin/tests/unit/test_security_policy.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
+from zakuro_poc.config import ZakuroPocConfig
 from zakuro_poc.models import ExecutionPlan
 from zakuro_poc.security.policy import validate_security_policy
 from zakuro_poc.validation import validate_plan_or_raise
@@ -62,10 +63,52 @@ def test_network_enabled_with_https_repo_url_accepted():
         network_enabled=True,
         repo_url="https://github.com/octocat/Hello-World.git",
     )
-    violations = validate_security_policy(plan)
+    violations = validate_security_policy(plan, ZakuroPocConfig(allow_network=True))
     assert not violations
 
 
 def test_non_https_repo_rejected():
     with pytest.raises(ValidationError):
         ExecutionPlan(job_name="test", command=["ls"], repo_url="http://github.com")
+
+
+def test_network_requires_config_approval():
+    plan = ExecutionPlan(
+        job_name="test",
+        command=["ls"],
+        network_enabled=True,
+        repo_url="https://github.com/octocat/Hello-World.git",
+    )
+    violations = validate_security_policy(plan)
+    assert any("config does not allow network access" in v for v in violations)
+
+
+def test_resource_limits_must_fit_configured_maxima():
+    plan = ExecutionPlan(job_name="test", command=["ls"])
+    plan.resource_limits.timeout_seconds = 120
+    plan.resource_limits.memory_mb = 2048
+    plan.resource_limits.cpu_count = 2.0
+
+    config = ZakuroPocConfig(max_timeout_seconds=60, max_memory_mb=1024, max_cpu_count=1.0)
+    violations = validate_security_policy(plan, config)
+
+    assert any("timeout exceeds configured maximum" in v for v in violations)
+    assert any("memory exceeds configured maximum" in v for v in violations)
+    assert any("CPU count exceeds configured maximum" in v for v in violations)
+
+
+def test_config_can_explicitly_allow_shell_and_latest_image():
+    plan = ExecutionPlan(job_name="test", command=["bash", "-lc", "true"], image="ubuntu:latest")
+
+    config = ZakuroPocConfig(allow_shell=True, allow_latest_images=True)
+    violations = validate_security_policy(plan, config)
+
+    assert not violations
+
+
+def test_working_dir_must_be_relative_under_workspace():
+    absolute = ExecutionPlan(job_name="absolute", command=["ls"], working_dir="/tmp")
+    traversal = ExecutionPlan(job_name="traversal", command=["ls"], working_dir="../outside")
+
+    assert any("working_dir" in v for v in validate_security_policy(absolute))
+    assert any("working_dir" in v for v in validate_security_policy(traversal))

--- a/zakuro-poc-plugin/tests/unit/test_security_policy.py
+++ b/zakuro-poc-plugin/tests/unit/test_security_policy.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from zakuro_poc.config import ZakuroPocConfig
-from zakuro_poc.models import ExecutionPlan
+from zakuro_poc.models import ExecutionPlan, ResourceLimits
 from zakuro_poc.security.policy import validate_security_policy
 from zakuro_poc.validation import validate_plan_or_raise
 
@@ -112,3 +112,43 @@ def test_working_dir_must_be_relative_under_workspace():
 
     assert any("working_dir" in v for v in validate_security_policy(absolute))
     assert any("working_dir" in v for v in validate_security_policy(traversal))
+
+
+def test_security_policy_rejects_empty_command_via_construct():
+    plan = ExecutionPlan.model_construct(
+        job_name="empty",
+        backend="docker",
+        image="python:3.11-slim",
+        command=[],
+        working_dir=None,
+        repo_url=None,
+        env={},
+        resource_limits=ResourceLimits(),
+        artifact_dir=None,
+        network_enabled=False,
+        created_by="claude-code",
+    )
+
+    violations = validate_security_policy(plan)
+
+    assert "empty command" in violations
+
+
+def test_security_policy_rejects_non_https_repo_via_construct():
+    plan = ExecutionPlan.model_construct(
+        job_name="repo",
+        backend="docker",
+        image="python:3.11-slim",
+        command=["ls"],
+        working_dir=None,
+        repo_url="http://example.com/repo.git",
+        env={},
+        resource_limits=ResourceLimits(),
+        artifact_dir=None,
+        network_enabled=False,
+        created_by="claude-code",
+    )
+
+    violations = validate_security_policy(plan)
+
+    assert "non-HTTPS repo_url" in violations

--- a/zakuro-poc-plugin/tests/unit/test_security_policy.py
+++ b/zakuro-poc-plugin/tests/unit/test_security_policy.py
@@ -1,0 +1,71 @@
+import pytest
+from pydantic import ValidationError
+
+from zakuro_poc.models import ExecutionPlan
+from zakuro_poc.security.policy import validate_security_policy
+from zakuro_poc.validation import validate_plan_or_raise
+
+
+def test_safe_python_command_accepted():
+    plan = ExecutionPlan(job_name="test", command=["python", "-c", "print('hello')"])
+    violations = validate_security_policy(plan)
+    assert not violations
+    validate_plan_or_raise(plan)
+
+
+def test_bash_c_rejected():
+    plan = ExecutionPlan(job_name="test", command=["bash", "-c", "ls"])
+    violations = validate_security_policy(plan)
+    assert any("shell interpreters" in v for v in violations)
+
+
+def test_sh_c_rejected():
+    plan = ExecutionPlan(job_name="test", command=["sh", "-c", "ls"])
+    violations = validate_security_policy(plan)
+    assert any("shell interpreters" in v for v in violations)
+
+
+def test_image_using_latest_rejected():
+    plan = ExecutionPlan(job_name="test", command=["ls"], image="ubuntu:latest")
+    violations = validate_security_policy(plan)
+    assert any("latest" in v for v in violations)
+
+
+def test_env_var_api_token_rejected():
+    plan = ExecutionPlan(job_name="test", command=["ls"], env={"API_TOKEN": "value"})
+    violations = validate_security_policy(plan)
+    assert any("suggests secret" in v for v in violations)
+
+
+def test_env_var_password_rejected():
+    plan = ExecutionPlan(job_name="test", command=["ls"], env={"DB_PASSWORD": "value"})
+    violations = validate_security_policy(plan)
+    assert any("suggests secret" in v for v in violations)
+
+
+def test_artifact_path_traversal_rejected():
+    plan = ExecutionPlan(job_name="test", command=["ls"], artifact_dir="../../etc/shadow")
+    violations = validate_security_policy(plan)
+    assert any("path traversal" in v for v in violations)
+
+
+def test_network_enabled_without_repo_url_rejected():
+    plan = ExecutionPlan(job_name="test", command=["ls"], network_enabled=True)
+    violations = validate_security_policy(plan)
+    assert any("network enabled without repo_url" in v for v in violations)
+
+
+def test_network_enabled_with_https_repo_url_accepted():
+    plan = ExecutionPlan(
+        job_name="test",
+        command=["ls"],
+        network_enabled=True,
+        repo_url="https://github.com/octocat/Hello-World.git",
+    )
+    violations = validate_security_policy(plan)
+    assert not violations
+
+
+def test_non_https_repo_rejected():
+    with pytest.raises(ValidationError):
+        ExecutionPlan(job_name="test", command=["ls"], repo_url="http://github.com")


### PR DESCRIPTION
## Summary
  This branch adds the `zakuro-poc-plugin` as an implemented AI coding agent POC with:
  - validated plan parsing and security policy enforcement
  - structured execution artifacts
  - non-root Docker execution by default
  - a fake backend contract suite
  - a conservative `ZakuroBackend` subprocess adapter for `zc execute`
  - root GitHub Actions coverage for the plugin
  - full local test coverage for `zakuro_poc`

  ## Validation
  - `pytest --cov=zakuro_poc --cov-report=term-missing`
  - `ruff format --check .`
  - `ruff check .`
  - `mypy src`
  - `git diff --check`
  - Docker-backed integration tests passed against a reachable daemon

  ## Notes
  The plugin is complete with limitations. The native `zc` path is currently a subprocess adapter and remains dependent on the
  external `zc` contract.