### PR TITLE
ci: move self-hosted jobs to ARC `cpu` scale set

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
   # -------------------------------------------------------------------
   sdist:
     name: sdist
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -97,7 +97,7 @@ jobs:
   # -------------------------------------------------------------------
   sbom:
     name: SBOM
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -122,7 +122,7 @@ jobs:
   hashes:
     name: Compute artifact hashes (for SLSA)
     needs: [wheels, sdist]
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
@@ -161,7 +161,7 @@ jobs:
     name: Publish to PyPI (Trusted Publishing)
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
     needs: [wheels, sdist, sbom]
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     environment:
       name: release
       url: https://pypi.org/project/sakura-ml/
@@ -195,7 +195,7 @@ jobs:
     name: Attach SBOM to release
     if: github.event_name == 'release'
     needs: [sbom, publish]
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     permissions:
       contents: write
     steps:

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   codeql-python:
     name: CodeQL (python)
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v4
@@ -36,7 +36,7 @@ jobs:
 
   semgrep:
     name: Semgrep (python.security + custom rules)
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     # Report-only on introduction. Sakura has a known cloudpickle call site
     # in sakura/dispatch/remote.py:27 that the custom rule will flag — that
     # site is exactly what zakuro#117 will migrate to a safe wire format,
@@ -68,7 +68,7 @@ jobs:
 
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   pip-audit:
     name: pip-audit (PyPI advisories)
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
     # accept continue-on-error on the caller) and install the binary
     # directly so we can pipe through `|| true` and keep the job green
     # while still uploading SARIF.
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - name: Install osv-scanner
@@ -97,7 +97,7 @@ jobs:
 
   cargo-audit:
     name: cargo-audit (Rust crates)
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -112,7 +112,7 @@ jobs:
 
   trivy-fs:
     name: trivy fs (repo)
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - name: Run trivy fs (report-only)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   rust:
     name: Rust
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -29,7 +29,7 @@ jobs:
 
   python:
     name: Python ${{ matrix.python }}
-    runs-on: [self-hosted, cpu]
+    runs-on: cpu
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Move self-hosted CI jobs from the single static runner to the new **ARC `cpu` scale set** (autoscaling 1→8 ephemeral dind runners on the 20-core `gha-runner-cpu` node, GitOps-managed via actions-runner-controller).

`runs-on: [self-hosted, cpu]` / `[self-hosted, i9-cpu]` → `runs-on: cpu`. `ubuntu-latest` jobs unchanged; no `gpu` jobs affected.

The static `i9-cpu` runner also carries the `cpu` label, so this is a zero-downtime transition — jobs run on ARC or the old runner until the latter is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)