### PR TITLE
security: run PR CI on GitHub-hosted runners

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   codeql-python:
     name: CodeQL (python)
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v4
@@ -36,7 +36,7 @@ jobs:
 
   semgrep:
     name: Semgrep (python.security + custom rules)
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     # Report-only on introduction. Sakura has a known cloudpickle call site
     # in sakura/dispatch/remote.py:27 that the custom rule will flag — that
     # site is exactly what zakuro#117 will migrate to a safe wire format,
@@ -68,7 +68,7 @@ jobs:
 
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   pip-audit:
     name: pip-audit (PyPI advisories)
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
     # accept continue-on-error on the caller) and install the binary
     # directly so we can pipe through `|| true` and keep the job green
     # while still uploading SARIF.
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - name: Install osv-scanner
@@ -97,7 +97,7 @@ jobs:
 
   cargo-audit:
     name: cargo-audit (Rust crates)
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -112,7 +112,7 @@ jobs:
 
   trivy-fs:
     name: trivy fs (repo)
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - name: Run trivy fs (report-only)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   rust:
     name: Rust
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -29,7 +29,7 @@ jobs:
 
   python:
     name: Python ${{ matrix.python }}
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Why

`zakuro-ai/sakura` is a **public** repository. Until now its `pull_request`-triggered CI jobs ran on **self-hosted runners** (`runs-on: cpu`). On a public repo this is a real RCE exposure: anyone can open a fork PR whose workflow code executes on our self-hosted infrastructure, giving an attacker arbitrary code execution on the runner host (and access to anything that host can reach on the network).

The org just **disabled public-repo access to the self-hosted runner group**, which closes that hole — but it also means this repo's PR CI is currently **broken**: every `pull_request` job is stuck with no eligible runner.

## What this does

For every job triggered by `pull_request`, route it to a GitHub-hosted `ubuntu-latest` runner while keeping self-hosted (`cpu`) for `push` / `schedule` / `workflow_dispatch` events:

```yaml
runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
```

This fixes PR CI **and** permanently removes the fork-PR RCE risk, while preserving self-hosted runners for trusted internal events. Sakura's CI (Rust + maturin + pytest, plus the SAST/scanner lanes) runs fine on `ubuntu-latest`.

Release/publish workflows are **not** touched — `publish.yml` only triggers on `workflow_dispatch` / `release` / tag pushes (never `pull_request`), so it keeps its existing runner setup.

## Files changed

- `.github/workflows/test.yml` — jobs `rust`, `python`
- `.github/workflows/sast.yml` — jobs `codeql-python`, `semgrep`, `gitleaks`
- `.github/workflows/security-scan.yml` — jobs `pip-audit`, `osv-scanner`, `cargo-audit`, `trivy-fs`

9 jobs total; `runs-on` is the only line changed in each. Indentation preserved; all workflow files validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)