### PR TITLE
fix(ci): run public-repo CI on ubuntu-latest

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   codeql-python:
     name: CodeQL (python)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v4
@@ -36,7 +36,7 @@ jobs:
 
   semgrep:
     name: Semgrep (python.security + custom rules)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     # Report-only on introduction. Sakura has a known cloudpickle call site
     # in sakura/dispatch/remote.py:27 that the custom rule will flag — that
     # site is exactly what zakuro#117 will migrate to a safe wire format,
@@ -68,7 +68,7 @@ jobs:
 
   gitleaks:
     name: gitleaks (secrets)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   pip-audit:
     name: pip-audit (PyPI advisories)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
     # accept continue-on-error on the caller) and install the binary
     # directly so we can pipe through `|| true` and keep the job green
     # while still uploading SARIF.
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install osv-scanner
@@ -97,7 +97,7 @@ jobs:
 
   cargo-audit:
     name: cargo-audit (Rust crates)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -112,7 +112,7 @@ jobs:
 
   trivy-fs:
     name: trivy fs (repo)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Run trivy fs (report-only)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   rust:
     name: Rust
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -29,7 +29,7 @@ jobs:
 
   python:
     name: Python ${{ matrix.python }}
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

sakura is a **public** repo, but `sast`, `security-scan`, and `test` used `runs-on: cpu` (self-hosted) for push/schedule events. The org runner group has `allows_public_repositories=false` (the safe default that avoids the public-repo self-hosted-runner RCE risk), so those runs queued forever / were cancelled and never reported a status — leaving the Actions tab perpetually un-cleared.

## Fix

Move `sast`, `security-scan`, `test` to `ubuntu-latest` for **every** event (PR runs already used `ubuntu-latest`, and the `security/pr-ci-github-hosted` branch already validated this path). Toolchains are set up in-workflow (`setup-uv`, `dtolnay/rust-toolchain`), so nothing depends on the self-hosted image.

`publish.yml` (release pipeline) is intentionally left on the self-hosted runner.

We did **not** enable `allows_public_repositories` (would re-introduce the audit's #1 RCE risk).