### PR TITLE
chore(governance): add standard governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in this repo.
+# Required reviewers for all pull requests (see branch protection).
+* @JeanMaximilienCadic

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a problem
+title: "[bug] "
+labels: bug
+---
+
+## Description
+
+<!-- What happened? What did you expect? -->
+
+## Steps to reproduce
+
+1.
+2.
+
+## Environment
+
+- Version / commit:
+- OS / platform:
+
+## Additional context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: mailto:security@zakuro-ai.com
+    about: Report security vulnerabilities privately by email, not as a public issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What
+
+<!-- What does this PR change? -->
+
+## Why
+
+<!-- Motivation / linked issue. -->
+
+Closes #
+
+## Testing
+
+<!-- How was this verified? Commands run, results observed. -->
+
+## Checklist
+
+- [ ] Lint / format pass locally
+- [ ] Tests added or updated (or N/A with reason)
+- [ ] Docs updated (or N/A)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thanks for contributing to a Zakuro project.
+
+## Workflow
+
+1. Create a branch from `main`: `feat/<short-name>` or `fix/<short-name>`.
+2. Make your change. Keep commits focused and messages descriptive.
+3. Run the project's lint, format, and test commands before pushing.
+4. Open a pull request against `main` and fill in the PR template.
+5. A pull request requires **1 approving review** from a code owner and all
+   status checks to pass before it can be merged.
+6. Merges use squash or rebase (linear history); the branch is deleted on merge.
+
+## Standards
+
+- Match the existing code style; run the configured formatter/linter.
+- Add or update tests for behavioral changes.
+- Update documentation (README / docs) when behavior or interfaces change.
+- Never commit secrets — see [SECURITY.md](SECURITY.md).
+
+## Questions
+
+Open a GitHub issue or reach the team at hello@zakuro-ai.com.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately** to **security@zakuro-ai.com**.
+Do not open a public issue for security problems.
+
+Include where possible:
+- A description of the vulnerability and its impact
+- Steps to reproduce or a proof of concept
+- Affected version(s) / commit
+
+We aim to acknowledge reports within 3 business days.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version and the default
+(`main`) branch. Older versions are not maintained.
+
+## Secrets
+
+Never commit secrets (`.env`, private keys, credentials, database dumps) to this
+repository. Such files must be listed in `.gitignore`. If a secret is committed,
+treat it as compromised: rotate it immediately and purge it from git history.


### PR DESCRIPTION
Adds standard governance files missing from this repo, per the 2026 Q2 repo health audit campaign (see `zakuro-infra/docs/superpowers/specs/2026-06-20-repo-health-audit-design.md`).

Added: .github/CODEOWNERS .github/pull_request_template.md SECURITY.md CONTRIBUTING.md .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/bug_report.md

Part of the campaign's governance-hardening pass.