### PR TITLE
fix: update stale README install note — alpha wheels are on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ uv pip install maturin
 maturin develop --release
 ```
 
-> **Wheel packaging** is being finalized — until then, the from-source path is the recommended install.
+> Alpha wheels are available on PyPI (`pip install sakura-ml`). Platform wheels for Linux x86_64/aarch64, macOS arm64, and Windows x86_64 are built automatically on release.
 
 ## Quickstart
 


### PR DESCRIPTION
Closes #105

## What changed

Replaced the stale blockquote on README.md line 60 that said wheel packaging was "being finalized" with accurate text reflecting that `1.0.0a1` is already published on PyPI.

**Before:**
> **Wheel packaging** is being finalized — until then, the from-source path is the recommended install.

**After:**
> Alpha wheels are available on PyPI (`pip install sakura-ml`). Platform wheels for Linux x86_64/aarch64, macOS arm64, and Windows x86_64 are built automatically on release.