### PR TITLE
fix: remove non-existent lightning extra from README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You install services on a `SakuraRuntime`, attach an adapter to your training lo
 ```bash
 pip install sakura-ml
 # or with framework integrations:
-pip install 'sakura-ml[lightning,huggingface]'
+pip install 'sakura-ml[huggingface]'
 ```
 
 From source:


### PR DESCRIPTION
Closes #97

## What was fixed

In `README.md` line 49, the install example referenced a `[lightning]` extra that does not exist in `pyproject.toml`:

```bash
# Before
pip install 'sakura-ml[lightning,huggingface]'

# After
pip install 'sakura-ml[huggingface]'
```

## Why

`lightning` is already a direct dependency of `sakura-ml`, so users get it automatically when installing the package. There is no `[lightning]` extra defined in `pyproject.toml`, meaning the old command would produce a pip warning/error about an unknown extra.