### PR TITLE
fix: add concurrency guards and top-level permissions to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     branches: [master]
   pull_request:
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
Closes #94

## What changed

Added two top-level blocks to `.github/workflows/test.yml`:

- **`concurrency`**: cancels in-progress runs for the same ref when a new push arrives, preventing redundant CI runs
- **`permissions: contents: read`**: restricts the default GITHUB_TOKEN to read-only, following least-privilege best practices

`publish.yml` already has top-level permissions so no change is needed there.