### PR TITLE
fix: declare cloudpickle as runtime dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "ipython",
     "charset-normalizer>=3.1.0",
     "zakuro-ai>=0.2.23",
+    "cloudpickle",
 ]
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
Closes #96

## What

Added `cloudpickle` to the `[project].dependencies` list in `pyproject.toml`.

## Why

`cloudpickle` is imported at module level in the sakura package but was missing from the declared runtime dependencies. This caused `ImportError` for users who installed the package without `cloudpickle` already present in their environment.

## Change

Single-line addition to `pyproject.toml`:

```toml
"cloudpickle",
```

Added alongside the other runtime dependencies (torch, lightning, etc.).