### PR TITLE
fix: add CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![test](https://github.com/zakuro-ai/sakura/actions/workflows/test.yml/badge.svg)](https://github.com/zakuro-ai/sakura/actions/workflows/test.yml)
+[![sast](https://github.com/zakuro-ai/sakura/actions/workflows/sast.yml/badge.svg)](https://github.com/zakuro-ai/sakura/actions/workflows/sast.yml)
+[![PyPI](https://img.shields.io/pypi/v/sakura-ml)](https://pypi.org/project/sakura-ml/)
+
 <h1 align="center">Sakura</h1>
 
 <p align="center">


### PR DESCRIPTION
Closes #106

## Summary

- Added `test` workflow badge linking to the CI test workflow
- Added `sast` workflow badge linking to the SAST security workflow
- Added PyPI badge for `sakura-ml` package

Both workflow files (`test.yml` and `sast.yml`) are confirmed to exist in `.github/workflows/`.

## Test plan

- [ ] Verify badges render correctly on the GitHub repository page
- [ ] Verify badge links point to the correct workflow runs
- [ ] Verify PyPI badge shows the correct package version