### PR TITLE
fix: add version floors to torch and torchvision dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ requires-python = ">=3.10"
 authors = [{ name = "ZakuroAI", email = "git@zakuro.ai" }]
 dependencies = [
     "tqdm>=4.68.1",
-    "torch",
-    "torchvision",
+    "torch>=2.0",
+    "torchvision>=0.15",
     "numpy",
     "gnutools-python",
     "chardet",


### PR DESCRIPTION
Closes #98

## What changed

In `pyproject.toml`, added minimum version constraints to the two previously unconstrained PyTorch dependencies:

- `"torch"` → `"torch>=2.0"`
- `"torchvision"` → `"torchvision>=0.15"`

## Why

Without version floors, pip may resolve to an ancient torch release that predates `torch.compile` and other features the package relies on. The 2.0 / 0.15 lower bounds are the minimum versions that support `torch.compile` and are safe for the rest of the dependency graph.