### PR TITLE
fix: add explicit MSRV (rust-version = "1.85") to workspace.package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "1.0.0-alpha.1"
 edition = "2021"
+rust-version = "1.85"
 license = "BSD-3-Clause"
 repository = "https://github.com/zakuro-ai/sakura"
 


### PR DESCRIPTION
Closes #99

## What

Add `rust-version = "1.85"` to the `[workspace.package]` section of `Cargo.toml`.

## Why

The workspace lacked an explicit MSRV field, making it unclear what minimum Rust version is required. This single-line addition declares the MSRV consistent with the rest of the Zakuro ecosystem (Rust 1.85).

With `rust-version` set, `cargo check --rust-version` and `cargo build --rust-version` will emit a clear error if a user's toolchain is too old, rather than a cryptic compile failure.