### PR TITLE
fix: use ubuntu-latest runner for sdist, sbom, hashes, publish, and attach-sbom jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
   # -------------------------------------------------------------------
   sdist:
     name: sdist
-    runs-on: cpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -97,7 +97,7 @@ jobs:
   # -------------------------------------------------------------------
   sbom:
     name: SBOM
-    runs-on: cpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
@@ -122,7 +122,7 @@ jobs:
   hashes:
     name: Compute artifact hashes (for SLSA)
     needs: [wheels, sdist]
-    runs-on: cpu
+    runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
@@ -161,7 +161,7 @@ jobs:
     name: Publish to PyPI (Trusted Publishing)
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
     needs: [wheels, sdist, sbom]
-    runs-on: cpu
+    runs-on: ubuntu-latest
     environment:
       name: release
       url: https://pypi.org/project/sakura-ml/
@@ -195,7 +195,7 @@ jobs:
     name: Attach SBOM to release
     if: github.event_name == 'release'
     needs: [sbom, publish]
-    runs-on: cpu
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Closes #100

## What

Replace all 5 occurrences of `runs-on: cpu` with `runs-on: ubuntu-latest` in `.github/workflows/publish.yml`.

## Affected jobs

| Line | Job |
|------|-----|
| 76 | `sdist` |
| 100 | `sbom` |
| 125 | `hashes` |
| 164 | `publish` |
| 198 | `attach-sbom` |

The `cpu` label refers to a self-hosted runner that is not available in this repo's context. Switching to `ubuntu-latest` uses the standard GitHub-hosted runner, which is the correct target for all these jobs.

Purely mechanical substitution — no logic changes.