### PR TITLE
fix: pin trivy-action to v0.36.0 stable release tag

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -119,7 +119,7 @@ jobs:
         # exit-code: "0" so the action does not fail the job on findings;
         # SARIF still uploads to the code-scanning view. Drop this once
         # the repo carries no HIGH/CRITICAL trivy fs findings.
-        uses: aquasecurity/trivy-action@cf5c088a69634cd13ccddc735d7926162c31f9a6  # master
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
Closes #90

## What changed

In `.github/workflows/security-scan.yml` line 122, replaced:

```yaml
uses: aquasecurity/trivy-action@cf5c088a69634cd13ccddc735d7926162c31f9a6  # master
```

with:

```yaml
uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
```

## Why

The previous commit hash was pinned to the `master` branch tip at a point in time. While a hash pin is safer than `@master` directly, the comment made clear it was tracking master — meaning it could fall behind or be intentionally updated to track a mutable ref. Pinning to a stable release tag SHA (`v0.36.0`, released 2026-04-22) makes the intent explicit and the version auditable.

## Supply-chain hygiene

- Uses the SHA of the `v0.36.0` tag for immutable pinning
- Tag comment makes the version human-readable
- No behavioral change to the scan — same action, newer stable version