### PR TITLE
fix: run full Python test suite in CI, not just tests/wire/ (closes #92)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,5 +58,5 @@ jobs:
         run: |
           source .venv/bin/activate
           maturin develop --release
-      - name: Pytest (wire layer only — Plan 1)
-        run: .venv/bin/pytest tests/wire/ -v
+      - name: Pytest (full suite)
+        run: .venv/bin/pytest tests/ -v --ignore=tests/bench -m 'not gpu'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ sakura-bench = "sakura.bench.__main__:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "gpu: tests that require CUDA hardware (deselected in CPU-only CI with -m 'not gpu')",
+]
 
 [tool.maturin]
 manifest-path = "crates/sakura-wire/Cargo.toml"

--- a/tests/zero/test_sharded_optimizer_nccl.py
+++ b/tests/zero/test_sharded_optimizer_nccl.py
@@ -128,6 +128,7 @@ def _run_multi_rank_nccl(step_count: int) -> dict:
                 os.unlink(init_file)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not (dist.is_available() and dist.is_nccl_available()
          and torch.cuda.is_available() and torch.cuda.device_count() >= WORLD_SIZE),


### PR DESCRIPTION
## Summary

Fixes #92. The `python` job in `test.yml` only ran `pytest tests/wire/` (the "Plan 1" subset), so roughly 90% of the suite — `tests/adapters/`, `tests/dispatch/`, `tests/runtime/`, `tests/services/`, `tests/zero/`, `tests/worker/` — never executed in CI. Breaking changes to adapters, services, dispatch, or ZeRO logic could pass CI silently.

## Changes

- **`.github/workflows/test.yml`** — pytest step now runs `pytest tests/ -v --ignore=tests/bench -m 'not gpu'` (was `pytest tests/wire/ -v`); step renamed from "wire layer only — Plan 1" to "full suite".
- **`tests/zero/test_sharded_optimizer_nccl.py`** — the GPU-only NCCL correctness test is marked `@pytest.mark.gpu` so it's deselected on CPU-only runners (per the issue's proposed fix). The existing `skipif` guard is retained.
- **`pyproject.toml`** — registers the `gpu` marker under `[tool.pytest.ini_options]` so it doesn't raise an unknown-marker warning.

No install-step change was needed: `maturin develop --release` already installs the package's declared deps (torch, torchvision, lightning, numpy, cloudpickle, zakuro-ai), which I verified locally.

## What runs vs. skips on the CPU-only `ubuntu-latest` runner

- ✅ Runs: adapters, dispatch, runtime, services, zero (gloo multi-rank), worker, wire.
- ⏭️ Deselected: NCCL GPU test (`-m 'not gpu'`).
- ⏭️ Self-skips: HF adapter test (`importorskip transformers`; the extra isn't installed).
- `tests/bench` is excluded per the issue (may need heavy/HF deps).

## Validation

Reproduced the exact CI flow locally (Python 3.12 venv, `maturin develop --release`, same pytest command):

```
129 passed, 1 skipped, 1 deselected in ~26s
```

The 1 skip is `test_hf_adapter.py` (transformers extra absent — same as CI); the 1 deselected is the NCCL GPU test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)