### PR TITLE
fix: repair silently-disabled Semgrep cloudpickle rule (follow-up to #89/#128)

### DIFF
--- a/.semgrep/sakura.yml
+++ b/.semgrep/sakura.yml
@@ -1,8 +1,10 @@
 # Custom Semgrep rules for sakura. Mirror of zakuro's .semgrep/zakuro.yml
-# with the same cloudpickle / pickle ban. Sakura has a known call site at
-# sakura/dispatch/remote.py:27 (cloudpickle.loads(wire_result.aux)) that
-# zakuro#117 will migrate to the safe wire format — this rule keeps the
-# concern visible until that lands.
+# with the same cloudpickle / pickle ban. This lane is BLOCKING in sast.yml:
+# the cloudpickle rule below fails CI on any new call site. The accepted
+# dispatch-RPC sites (sakura/dispatch/remote.py, sakura/worker/handlers.py)
+# carry inline `# nosemgrep` suppressions justified by the documented trust
+# model (SECURITY.md). Eliminating the primitive entirely is tracked in
+# zakuro#117.
 
 rules:
   - id: sakura.deserialization.cloudpickle-loads-untrusted
@@ -10,28 +12,29 @@ rules:
     languages: [python]
     message: >-
       cloudpickle.loads / pickle.loads on attacker-influenced input is a
-      remote-code-execution primitive. The Zakuro wire format is being
-      migrated off cloudpickle (zakuro#117); until that lands, every call
-      site that deserialises an untrusted byte stream must go through the
-      vetted `zakuro.wire.safe_loads` adapter, not raw cloudpickle.
+      remote-code-execution primitive (CWE-502). Do not add a new call site.
+      The only accepted sites are the dispatch RPC's, which run under the
+      documented trust model (operator-controlled worker, pinned-cert QUIC
+      channel — see SECURITY.md) and carry a justified
+      `# nosemgrep: sakura.deserialization.cloudpickle-loads-untrusted`.
+      Eliminating the primitive entirely is tracked in zakuro#117.
     metadata:
       category: security
       cwe: "CWE-502: Deserialization of Untrusted Data"
       references:
         - https://docs.python.org/3/library/pickle.html#module-pickle
         - https://github.com/zakuro-ai/zakuro/issues/117
-    patterns:
-      - pattern-either:
-          - pattern: cloudpickle.loads(...)
-          - pattern: pickle.loads(...)
-          - pattern: cloudpickle.load(...)
-          - pattern: pickle.load(...)
-      - pattern-not-inside: |
-          # type: ignore[zakuro-safe-pickle]
-          ...
-      - pattern-not-inside: |
-          def safe_loads(...):
-              ...
+    # Accepted call sites are suppressed inline with
+    # `# nosemgrep: sakura.deserialization.cloudpickle-loads-untrusted`
+    # (semgrep-native). Do NOT add a `pattern-not-inside` against a comment
+    # line to express exceptions: semgrep matches the AST and strips comments,
+    # so such a clause collapses to a bare `...` that matches every enclosing
+    # context — which silently disabled this entire rule until it was removed.
+    pattern-either:
+      - pattern: cloudpickle.loads(...)
+      - pattern: pickle.loads(...)
+      - pattern: cloudpickle.load(...)
+      - pattern: pickle.load(...)
 
   - id: sakura.subprocess.shell-true
     severity: WARNING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ pre-release spelling (`1.0.0a1`); the Rust crate uses the SemVer equivalent
 
 ## [Unreleased]
 
+### Fixed
+
+- **Security:** the Semgrep `cloudpickle-loads-untrusted` rule was silently
+  disabled — its `pattern-not-inside` clause matched a comment line, which
+  semgrep strips, collapsing the clause to a bare `...` that excluded every
+  context. The blocking lane (#89) therefore caught no cloudpickle call sites.
+  Removed the broken clause so the rule actually fires; accepted sites stay
+  suppressed via inline `# nosemgrep`. (#89)
+
 ## [1.0.0a1] — 2026-05-09
 
 v1.0 is a clean break from v0.1.x. The library was rebuilt around an **event


### PR DESCRIPTION
## What

Follow-up to #89 / #128. #128 flipped the Semgrep lane to blocking (`--error`) and added `# nosemgrep` suppressions to the two accepted `cloudpickle.loads` sites — but **the custom cloudpickle rule never actually fired**, so the "blocking" lane caught nothing.

Root cause: the rule's `pattern-not-inside` clause was written against a *comment* line:

```yaml
- pattern-not-inside: |
    # type: ignore[zakuro-safe-pickle]
    ...
```

semgrep matches the AST and strips comments, so this collapses to `pattern-not-inside: ...` — a bare ellipsis that matches every enclosing context. The rule excluded *everything* and produced zero findings on any cloudpickle site.

This PR removes the broken clauses (exceptions are already expressed with semgrep-native inline `# nosemgrep`, which #128 added) and corrects the rule message, which pointed at a nonexistent `zakuro.wire.safe_loads` adapter.

## Why

Without this, `cloudpickle-loads-untrusted` is security theater: the lane is marked blocking but a newly-introduced `cloudpickle.loads` would merge clean. This makes the enforcement #128 intended actually work.

## Testing

Local Semgrep runs (custom rule):
- Unsuppressed `cloudpickle.loads` → **1 blocking** finding (rule is now live; on master it returns **0**).
- Full `sakura/` scan with `--error` → **0** findings (the two `# nosemgrep`-suppressed sites stay clean).
- Stripping a `# nosemgrep` → **1 blocking** (suppression is load-bearing, not a dead rule masking it).

## Checklist

- [x] Lint / format pass locally
- [x] Tests added or updated (N/A — Semgrep rule config; verified via the runs above)
- [x] Docs updated (rule message/header corrected; SECURITY.md already covered by #128)
- [x] CHANGELOG.md updated under `## [Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)