### PR TITLE
security: document cloudpickle trust model; flip Semgrep lane to strict (closes #89)

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -37,27 +37,20 @@ jobs:
   semgrep:
     name: Semgrep (python.security + custom rules)
     runs-on: ubuntu-latest
-    # Report-only on introduction. Sakura has a known cloudpickle call site
-    # in sakura/dispatch/remote.py:27 that the custom rule will flag — that
-    # site is exactly what zakuro#117 will migrate to a safe wire format,
-    # at which point we ratchet this lane back to strict.
-    #
-    # Drop `--error` (which is what makes semgrep exit non-zero on findings)
-    # so the JOB stays green even when findings are present; SARIF still
-    # uploads, the work stays visible.
     container:
       image: returntocorp/semgrep:1.92.0
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Mark workspace as a safe git directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Run Semgrep (report-only)
+      - name: Run Semgrep
         run: |
           semgrep scan \
             --config=p/python \
             --config=p/security-audit \
             --config=p/owasp-top-ten \
             --config=.semgrep/sakura.yml \
+            --error \
             --sarif --output=semgrep.sarif
       - name: Upload SARIF
         if: always() && hashFiles('semgrep.sarif') != ''

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,32 @@ We aim to acknowledge reports within 3 business days.
 Security fixes are applied to the latest released version and the default
 (`main`) branch. Older versions are not maintained.
 
+## RemoteDispatcher trust model
+
+`RemoteDispatcher` (and the `LocalDispatcher` that auto-spawns a local worker)
+use `cloudpickle` to serialise callables over the QUIC wire.
+**cloudpickle payloads are not cryptographically verified.** This means:
+
+- The worker you connect to **must be operator-controlled**. Connecting to an
+  untrusted or publicly-accessible endpoint lets a malicious worker return an
+  arbitrary cloudpickle payload that executes code in your training process
+  (CWE-502 / RCE).
+- Likewise, a worker exposes a `HANDLER_EXEC_CLOUDPICKLED` endpoint: do **not**
+  expose a sakura-worker's QUIC port to untrusted clients.
+
+The safe usage pattern is:
+```
+LocalDispatcher()          # auto-spawned localhost worker — safe
+RemoteDispatcher(uri=...)  # operator-controlled worker on a private network — safe
+RemoteDispatcher(uri=...)  # public/untrusted endpoint — NOT SAFE
+```
+
+Migration to a safe postcard/serde codec that eliminates cloudpickle from the
+RPC path is tracked in [zakuro#117](https://github.com/zakuro-ai/zakuro/issues/117).
+Until that lands, the two call sites are marked with
+`# nosemgrep: sakura.deserialization.cloudpickle-loads-untrusted` so the Semgrep
+gate blocks **new** cloudpickle call sites from being merged.
+
 ## Secrets
 
 Never commit secrets (`.env`, private keys, credentials, database dumps) to this

--- a/sakura/dispatch/remote.py
+++ b/sakura/dispatch/remote.py
@@ -24,6 +24,7 @@ class _WireFuture(Future):
 
     def result(self, timeout: Optional[float] = None) -> Result:
         wire_result = self._fut.result(timeout=timeout)
+        # nosemgrep: sakura.deserialization.cloudpickle-loads-untrusted
         value = cloudpickle.loads(wire_result.aux)
         if isinstance(value, BaseException):
             raise value

--- a/sakura/worker/handlers.py
+++ b/sakura/worker/handlers.py
@@ -65,6 +65,7 @@ def handle_exec_cloudpickled(tensors: list[dict], aux: bytes) -> Tuple[list[dict
     The decoded numpy arrays from `tensors` are passed as positional args BEFORE
     `args` so callers write `submit(fn, np_arr_1, np_arr_2, scalar=...)`.
     """
+    # nosemgrep: sakura.deserialization.cloudpickle-loads-untrusted
     spec = cloudpickle.loads(aux)
     fn = spec["fn"]
     extra_args = spec.get("args", ())


### PR DESCRIPTION
## Summary

- Adds `# nosemgrep: sakura.deserialization.cloudpickle-loads-untrusted` to the two known cloudpickle.loads call sites (`sakura/dispatch/remote.py:27`, `sakura/worker/handlers.py:68`), explicitly acknowledging them as reviewed pre-migration placeholders
- Updates `SECURITY.md` with the RemoteDispatcher trust model: worker must be operator-controlled; exposes the CWE-502 surface and links to zakuro#117 for the wire migration
- Re-enables `--error` in `sast.yml` Semgrep lane — any **new** cloudpickle.loads call site now fails CI at PR time

The full fix (eliminating cloudpickle from the RPC path) is tracked in zakuro#117. This PR closes the gate so nothing new can slip in.

## Test plan

- [ ] Semgrep CI lane passes (nosemgrep tokens suppress the two known sites)
- [ ] CodeQL and gitleaks still green
- [ ] All other CI jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)