### PR TITLE
refactor: make torch/lightning/torchvision optional dependencies (closes #71)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build + install via maturin develop
         run: |
           source .venv/bin/activate
-          maturin develop --release
+          maturin develop --release -E training
       - name: Pytest (full suite)
         run: .venv/bin/pytest tests/ -v --ignore=tests/bench -m 'not gpu'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,9 @@ requires-python = ">=3.10"
 authors = [{ name = "ZakuroAI", email = "git@zakuro.ai" }]
 dependencies = [
     "tqdm>=4.68.1",
-    "torch>=2.0",
-    "torchvision>=0.15",
     "numpy",
     "gnutools-python",
     "chardet",
-    "lightning",
     "ipython",
     "charset-normalizer>=3.4.7",
     "zakuro-ai>=0.2.23",
@@ -34,12 +31,18 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+training = [
+    "torch>=2.0",
+    "torchvision>=0.15",
+    "lightning",
+]
 huggingface = [
+    "sakura-ml[training]",
     "transformers>=5.10.2",
     "datasets>=4.8.5",
     "accelerate>=1.13.0",
 ]
-bench = ["sakura-ml[huggingface]"]
+bench = ["sakura-ml[training,huggingface]"]
 
 [dependency-groups]
 dev = ["pytest", "pytest-cov", "maturin>=1.4", "mypy>=1.13"]

--- a/sakura/zero/sharded_optimizer.py
+++ b/sakura/zero/sharded_optimizer.py
@@ -12,9 +12,6 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-import torch
-import torch.distributed as dist
-
 
 class ShardedOptimizer:
     """ZeRO stage-1 sharded optimizer wrapper.
@@ -30,10 +27,11 @@ class ShardedOptimizer:
 
     def __init__(
         self,
-        optimizer: torch.optim.Optimizer,
+        optimizer: Any,
         *,
         process_group: Optional[Any] = None,
     ):
+        import torch.distributed as dist
         self._opt = optimizer
         self._pg = process_group
         if dist.is_available() and dist.is_initialized():
@@ -57,7 +55,7 @@ class ShardedOptimizer:
                 idx += 1
         return owners
 
-    def _all_params(self) -> list[torch.nn.Parameter]:
+    def _all_params(self) -> list:
         out = []
         for group in self._opt.param_groups:
             out.extend(group["params"])
@@ -69,9 +67,11 @@ class ShardedOptimizer:
             # Single-rank passthrough.
             return self._opt.step(closure)
 
+        import torch.distributed as dist
+
         # Save grads of params NOT owned by this rank, zero them so the local
         # optimizer doesn't update those params, then restore after step.
-        saved_grads: dict[int, Optional[torch.Tensor]] = {}
+        saved_grads: dict[int, Any] = {}
         for p in self._all_params():
             if self._param_owner[id(p)] != self._rank:
                 saved_grads[id(p)] = p.grad


### PR DESCRIPTION
## Summary

- Moves `torch`, `torchvision`, and `lightning` out of `dependencies` into a new `[training]` optional extra
- `[huggingface]` and `[bench]` now depend on `[training]` transitively so existing install commands are unaffected
- `sakura/zero/sharded_optimizer.py` had the only top-level `import torch` outside bench/workloads — moved into `__init__` and `step()` so the module is importable without torch
- All service modules (`compile.py`, `mixed_precision.py`, etc.) already used lazy `import torch` inside methods — no changes needed there
- CI matrix job updated to `maturin develop --release -E training` so the full test suite continues to run against the training stack

**Install surface after this PR:**
```
pip install sakura-ml               # dispatch + ZakuroDispatcher + wire only
pip install sakura-ml[training]     # adds torch, torchvision, lightning
pip install sakura-ml[huggingface]  # training + transformers/datasets/accelerate
pip install sakura-ml[bench]        # training + huggingface + benchmark harness
```

## Test plan

- [ ] All CI jobs pass
- [ ] `python -c "import sakura"` works in a fresh venv without torch installed (verified by lazy-import audit above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)