### PR TITLE
fix: resolve wave-2 CodeQL alerts (catch-base-exception × 3, unused-local-variable)

### DIFF
--- a/sakura/dispatch/in_thread.py
+++ b/sakura/dispatch/in_thread.py
@@ -41,7 +41,7 @@ class InThreadDispatcher(Dispatcher):
         t0 = time.perf_counter_ns()
         try:
             value = callable(*args, **kwargs)
-        except BaseException as exc:  # noqa: BLE001  # lgtm[py/catch-base-exception]
+        except Exception as exc:
             return _ResolvedFuture(exc=exc, elapsed_us=(time.perf_counter_ns() - t0) // 1000)
         return _ResolvedFuture(value=value, elapsed_us=(time.perf_counter_ns() - t0) // 1000)
 

--- a/sakura/dispatch/zakuro.py
+++ b/sakura/dispatch/zakuro.py
@@ -53,7 +53,7 @@ class ZakuroDispatcher(Dispatcher):
         t0 = time.perf_counter_ns()
         try:
             value = _wrapped.to(self._zk_compute)(*args, **kwargs)
-        except BaseException as exc:  # noqa: BLE001  # lgtm[py/catch-base-exception]
+        except Exception as exc:
             return _ZkFuture(value=None, exc=exc,
                               elapsed_us=(time.perf_counter_ns() - t0) // 1000)
         return _ZkFuture(value=value, exc=None,

--- a/sakura/runtime.py
+++ b/sakura/runtime.py
@@ -122,11 +122,11 @@ class SakuraRuntime:
                 })
             return
 
-        errors: Optional[list[tuple[Service, BaseException]]] = None
+        errors: Optional[list[tuple[Service, Exception]]] = None
         for s in services:
             try:
                 s.on_event(event)
-            except BaseException as exc:  # noqa: BLE001  # lgtm[py/catch-base-exception]
+            except Exception as exc:
                 if errors is None:
                     errors = []
                 errors.append((s, exc))

--- a/tests/zero/test_sharded_optimizer.py
+++ b/tests/zero/test_sharded_optimizer.py
@@ -42,8 +42,8 @@ def _worker(rank, world_size, port):
         snapshot = p.detach().clone()
         dist.all_reduce(p.detach(), op=dist.ReduceOp.SUM)
         # If all ranks have the same value, sum should be world_size * snapshot.
-        _expected = snapshot * world_size
-        assert torch.allclose(p.detach() / world_size, snapshot, atol=1e-5)
+        expected = snapshot * world_size
+        assert torch.allclose(p.detach(), expected, atol=1e-5 * world_size)
         # Restore for next iteration (no-op since this is end of test)
         p.data.copy_(snapshot)
 


### PR DESCRIPTION
## Summary

Fixes four open code-scanning alerts surfaced after the wave-1 sweep (PR #124).

### `py/catch-base-exception` (alerts 101, 102, 103)

Changed `except BaseException` → `except Exception` in three dispatch/runtime spots:
- `sakura/dispatch/in_thread.py:44`
- `sakura/dispatch/zakuro.py:56`
- `sakura/runtime.py:129`

`KeyboardInterrupt` and `SystemExit` must not be swallowed by dispatch infrastructure — if a signal fires while user code is executing, it should propagate. The `# lgtm[]` comments added in #124 are a no-op because GitHub Code Scanning no longer honours that syntax.

### `py/unused-local-variable` (alert 104)

`tests/zero/test_sharded_optimizer.py:45` — `_expected` was computed but not used in the assertion. Renamed to `expected` and used directly: `torch.allclose(p.detach(), expected, atol=1e-5 * world_size)`. Semantically identical but clearer and lint-clean.

## Test plan

- [ ] All CI jobs pass
- [ ] Code scanning shows zero open alerts after the scan triggered by this merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)