### PR TITLE
feat: friendly missing-dependency errors + bare-install CI guard for optional ML deps (follow-up to #71/#129)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,39 @@ jobs:
       - name: Pytest (full suite)
         run: .venv/bin/pytest tests/ -v --ignore=tests/bench -m 'not gpu'
 
+  bare-install:
+    # Regression guard for #71: a core install (no extras) must import and run
+    # the dispatch / runtime / wire surface with NO PyTorch present. If any
+    # core module grows an eager torch import, this lane goes red.
+    name: Bare install (no ML stack)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+      - name: Install build deps
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip maturin pytest
+      - name: Build + install via maturin develop (no extras)
+        run: |
+          source .venv/bin/activate
+          maturin develop --release
+      - name: Assert torch is NOT installed
+        run: |
+          if .venv/bin/python -c "import torch" 2>/dev/null; then
+            echo "torch is installed in a bare environment — extras leaked into core deps"; exit 1
+          fi
+      - name: Smoke import + dispatch/optional-deps tests
+        run: |
+          .venv/bin/python -c "import sakura; from sakura.dispatch import RemoteDispatcher, LocalDispatcher; print('import ok')"
+          .venv/bin/pytest tests/dispatch tests/wire tests/test_optional_deps.py -v -m 'not gpu'
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ pre-release spelling (`1.0.0a1`); the Rust crate uses the SemVer equivalent
 
 ## [Unreleased]
 
+### Changed
+
+- **ML framework dependencies are now optional extras (BREAKING for installs).**
+  `pip install sakura-ml` no longer pulls PyTorch — the base install is the
+  dispatch / runtime / wire surface only. Install the training stack via
+  `sakura-ml[training]` (torch / torchvision / lightning), `sakura-ml[huggingface]`,
+  or `sakura-ml[bench]`. Using a training feature without its extra now raises a
+  `ModuleNotFoundError` with the exact `pip install` hint, via the new
+  `sakura._optional.load` helper. A `bare-install` CI lane guards the core
+  install against regressing to require torch. (#71)
+
 ## [1.0.0a1] — 2026-05-09
 
 v1.0 is a clean break from v0.1.x. The library was rebuilt around an **event

--- a/README.md
+++ b/README.md
@@ -47,11 +47,19 @@ You install services on a `SakuraRuntime`, attach an adapter to your training lo
 
 ## Install
 
+The base install is **dispatch / runtime / wire only** — it does **not** pull
+PyTorch, so it's lightweight for dispatch-only or API use. The ML framework
+dependencies live in extras:
+
 ```bash
-pip install sakura-ml
-# or with framework integrations:
-pip install 'sakura-ml[huggingface]'
+pip install sakura-ml                      # core: dispatch + runtime + wire (no torch)
+pip install 'sakura-ml[training]'          # + torch / torchvision / lightning — services, ZeRO, adapters
+pip install 'sakura-ml[huggingface]'       # + training + transformers/datasets/accelerate — the HFAdapter
+pip install 'sakura-ml[bench]'             # + everything the benchmark harness needs
 ```
+
+Using a training feature without the extra raises an error telling you exactly
+which extra to install (e.g. `pip install 'sakura-ml[training]'`).
 
 From source:
 

--- a/sakura/_optional.py
+++ b/sakura/_optional.py
@@ -1,0 +1,32 @@
+"""Lazy loader for optional (extra) dependencies.
+
+The core sakura surface (dispatch / runtime / events / wire) installs without
+the heavy ML stack. Training features import their dependencies through
+``load`` so that a missing dependency surfaces as an actionable install hint
+rather than a bare ``ModuleNotFoundError``.
+
+    torch = load("torch", extra="training")
+"""
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+
+def load(module: str, *, extra: str) -> ModuleType:
+    """Import ``module`` or raise with a ``pip install 'sakura-ml[extra]'`` hint.
+
+    ``extra`` is the optional-dependency group that provides ``module`` (e.g.
+    ``"training"`` for torch, ``"lightning"`` for lightning).
+    """
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:
+        raise ModuleNotFoundError(
+            f"sakura: this feature requires the optional dependency '{module}', "
+            f"which is not installed. Install it with: "
+            f"pip install 'sakura-ml[{extra}]'"
+        ) from exc
+
+
+__all__ = ["load"]

--- a/sakura/services/activation_checkpoint.py
+++ b/sakura/services/activation_checkpoint.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Literal, Union
 
+from sakura._optional import load
 from sakura.events import OnTrainBegin
 from sakura.service import BaseService
 
@@ -29,7 +30,7 @@ class ActivationCheckpoint(BaseService):
         self.wrapped_count = 0
 
     def on_train_begin(self, event: OnTrainBegin):
-        import torch.utils.checkpoint as _ck
+        _ck = load("torch.utils.checkpoint", extra="training")
 
         target_modules = []
         for module in event.model.modules():

--- a/sakura/services/async_checkpoint.py
+++ b/sakura/services/async_checkpoint.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 import os
 from typing import Any, Callable, Literal, Optional, Union
 
+from sakura._optional import load
 from sakura.dispatch.base import Dispatcher, Future
 from sakura.events import OnEpochEnd, OnTrainEnd
 from sakura.service import BaseService
 
 
 def _torch_save_writer(state, path):
-    import torch
+    torch = load("torch", extra="training")
     torch.save(state, path)
     return {"path": str(path)}
 

--- a/sakura/services/compile.py
+++ b/sakura/services/compile.py
@@ -13,6 +13,7 @@ import os
 import time
 from typing import Literal, Optional
 
+from sakura._optional import load
 from sakura.events import OnTrainBegin, OnTrainStepBegin
 from sakura.service import BaseService
 
@@ -41,7 +42,7 @@ class Compile(BaseService):
         self.first_step_secs: Optional[float] = None
 
     def on_train_begin(self, event: OnTrainBegin) -> None:
-        import torch
+        torch = load("torch", extra="training")
 
         os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", self._cache_dir)
         # Mark as "attempted" before the compile call — even if torch.compile

--- a/sakura/services/mixed_precision.py
+++ b/sakura/services/mixed_precision.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import Any, Literal, Optional, Union
 
+from sakura._optional import load
 from sakura.events import OnOptimizerStep, OnTrainBegin, OnTrainEnd, OnTrainStepBegin
 from sakura.service import BaseService
 
@@ -48,7 +49,7 @@ class MixedPrecision(BaseService):
         pass
 
     def on_train_begin(self, event: OnTrainBegin) -> None:
-        import torch
+        torch = load("torch", extra="training")
 
         # Determine device + actual dtype.
         device_type = self._device_type_from(event.model)
@@ -119,7 +120,7 @@ class MixedPrecision(BaseService):
         if self._scaler is not None:
             self._scaler.unscale_(opt)
         if self._grad_clip is not None:
-            import torch
+            torch = load("torch", extra="training")
 
             params = []
             for group in opt.param_groups:
@@ -163,7 +164,7 @@ class MixedPrecision(BaseService):
             return "cpu"
 
     def _resolve_dtype(self, device_type: str):
-        import torch
+        torch = load("torch", extra="training")
         if self._dtype == "auto":
             if torch.cuda.is_available():
                 cap = torch.cuda.get_device_capability()

--- a/sakura/zero/sharded_optimizer.py
+++ b/sakura/zero/sharded_optimizer.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+from sakura._optional import load
+
 
 class ShardedOptimizer:
     """ZeRO stage-1 sharded optimizer wrapper.
@@ -31,6 +33,9 @@ class ShardedOptimizer:
         *,
         process_group: Optional[Any] = None,
     ):
+        # torch is an optional ("training") dependency; surface a friendly
+        # install hint instead of a bare ModuleNotFoundError.
+        load("torch", extra="training")
         import torch.distributed as dist
         self._opt = optimizer
         self._pg = process_group

--- a/sakura/zero/sharded_optimizer.py
+++ b/sakura/zero/sharded_optimizer.py
@@ -33,10 +33,7 @@ class ShardedOptimizer:
         *,
         process_group: Optional[Any] = None,
     ):
-        # torch is an optional ("training") dependency; surface a friendly
-        # install hint instead of a bare ModuleNotFoundError.
-        load("torch", extra="training")
-        import torch.distributed as dist
+        dist = load("torch.distributed", extra="training")
         self._opt = optimizer
         self._pg = process_group
         if dist.is_available() and dist.is_initialized():

--- a/tests/test_optional_deps.py
+++ b/tests/test_optional_deps.py
@@ -93,3 +93,44 @@ def test_sharded_optimizer_without_torch_raises_install_hint():
     )
     assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
     assert "RAISED_HINT" in proc.stdout
+
+
+def test_activation_checkpoint_without_torch_raises_install_hint():
+    proc = _run_without_torch(
+        "from sakura.services import ActivationCheckpoint\n"
+        "svc = ActivationCheckpoint(target_types=(object,))\n"
+        "try:\n"
+        "    svc.on_train_begin(object())\n"
+        "except ModuleNotFoundError as e:\n"
+        "    assert 'sakura-ml[training]' in str(e), str(e)\n"
+        "    print('RAISED_HINT')\n"
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "RAISED_HINT" in proc.stdout
+
+
+def test_async_checkpoint_writer_without_torch_raises_install_hint():
+    proc = _run_without_torch(
+        "from sakura.services.async_checkpoint import _torch_save_writer\n"
+        "try:\n"
+        "    _torch_save_writer({}, '/tmp/x')\n"
+        "except ModuleNotFoundError as e:\n"
+        "    assert 'sakura-ml[training]' in str(e), str(e)\n"
+        "    print('RAISED_HINT')\n"
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "RAISED_HINT" in proc.stdout
+
+
+def test_mixed_precision_without_torch_raises_install_hint():
+    proc = _run_without_torch(
+        "from sakura.services import MixedPrecision\n"
+        "svc = MixedPrecision()\n"
+        "try:\n"
+        "    svc.on_train_begin(object())\n"
+        "except ModuleNotFoundError as e:\n"
+        "    assert 'sakura-ml[training]' in str(e), str(e)\n"
+        "    print('RAISED_HINT')\n"
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "RAISED_HINT" in proc.stdout

--- a/tests/test_optional_deps.py
+++ b/tests/test_optional_deps.py
@@ -1,0 +1,95 @@
+"""Optional-dependency behavior (issue #71).
+
+Sakura's core (dispatch / runtime / events / wire) must import without the
+heavy ML stack. Training features are gated behind extras and raise a friendly
+install hint when their dependency is missing.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# sakura._optional.load
+# --------------------------------------------------------------------------- #
+
+
+def test_load_returns_the_imported_module():
+    from sakura._optional import load
+
+    mod = load("json", extra="training")
+    import json
+
+    assert mod is json
+
+
+def test_load_missing_dependency_raises_with_install_hint():
+    from sakura._optional import load
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        load("a_module_that_does_not_exist_xyz", extra="training")
+
+    msg = str(excinfo.value)
+    assert "a_module_that_does_not_exist_xyz" in msg
+    assert "sakura-ml[training]" in msg
+
+
+# --------------------------------------------------------------------------- #
+# Core import-safety without torch (run in a subprocess with torch blocked)
+# --------------------------------------------------------------------------- #
+
+_BLOCK_TORCH = (
+    "import sys\n"
+    "sys.modules['torch'] = None\n"
+    "sys.modules['torch.distributed'] = None\n"
+)
+
+
+def _run_without_torch(body: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", _BLOCK_TORCH + body],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_sakura_without_torch():
+    proc = _run_without_torch(
+        "import sakura\n"
+        "from sakura import SakuraRuntime, Telemetry\n"
+        "from sakura.dispatch import RemoteDispatcher, LocalDispatcher\n"
+        "rt = SakuraRuntime()\n"
+        "print('OK')\n"
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "OK" in proc.stdout
+
+
+def test_service_torch_path_without_torch_raises_install_hint():
+    proc = _run_without_torch(
+        "from sakura.services import Compile\n"
+        "svc = Compile()\n"
+        "try:\n"
+        "    svc.on_train_begin(object())\n"
+        "except ModuleNotFoundError as e:\n"
+        "    assert 'sakura-ml[training]' in str(e), str(e)\n"
+        "    print('RAISED_HINT')\n"
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "RAISED_HINT" in proc.stdout
+
+
+def test_sharded_optimizer_without_torch_raises_install_hint():
+    proc = _run_without_torch(
+        "from sakura import ShardedOptimizer\n"
+        "try:\n"
+        "    ShardedOptimizer(object())\n"
+        "except ModuleNotFoundError as e:\n"
+        "    assert 'sakura-ml[training]' in str(e), str(e)\n"
+        "    print('RAISED_HINT')\n"
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "RAISED_HINT" in proc.stdout


### PR DESCRIPTION
## What

Follow-up to #71 / #129. #129 moved torch/torchvision/lightning to the `[training]` extra and made `sharded_optimizer` import-safe — but left three gaps this PR closes:

1. **No friendly error.** A missing training dep surfaced as a bare `ModuleNotFoundError: No module named 'torch'`. New `sakura/_optional.py` `load(module, *, extra)` raises with the exact `pip install 'sakura-ml[training]'` hint, and the services + ZeRO now route their torch imports through it.
2. **No regression guard.** Nothing stopped a future eager `import torch` in core code from silently breaking the bare install. Added `tests/test_optional_deps.py` and a **`bare-install` CI lane** (installs core only, asserts torch is absent, runs the dispatch/wire/optional-deps tests).
3. **No docs.** Added the extras table to the README and a CHANGELOG `[Unreleased]` entry (#129 added neither; the PR template requires the changelog).

Builds on master's `[training]` extra as-is — no change to the merged taxonomy.

## Testing (TDD — tests written first, watched fail)

- `_optional.load` returns the module / raises with the install hint.
- subprocess with `torch` + `torch.distributed` blocked: `import sakura`, `SakuraRuntime`, and `sakura.dispatch` all import torch-free.
- `ShardedOptimizer(...)` and a service (`Compile`) torch path each raise `ModuleNotFoundError` mentioning `sakura-ml[training]`.

Local: **74 passed** across optional-deps/services/zero/dispatch/wire (1 GPU test deselected); `ruff check` clean; mypy unaffected (hermetic lane, no numpy/torch).

## Note on the granular extras option

In our design discussion the granular split (`training`=torch, separate `lightning`, torchvision→`bench`) was preferred, but #129 merged the single `[training]` umbrella first. I kept the merged umbrella here to avoid churning a just-shipped public extra. If you still want the granular split, say so and I'll do it as its own small PR.

## Checklist

- [x] Lint / format pass locally
- [x] Tests added (`tests/test_optional_deps.py`)
- [x] Docs updated (README)
- [x] CHANGELOG.md updated under `## [Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)