### PR TITLE
fix(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asn1-rs"


### PR DESCRIPTION
## Summary
- The `osv-scanner (lockfiles)` job in `security-scan` has been failing on `master` every scheduled run since 2026-06-30 (exit code 1 = real vulnerability match, not a tool crash).
- Root cause: `anyhow 1.0.102` (transitive dependency, pulled in via the Cargo.lock dependency graph — no direct `Cargo.toml` pin) is affected by [RUSTSEC-2026-0190](https://osv.dev/vulnerability/RUSTSEC-2026-0190): `Error::downcast_mut()` violates Rust's borrow rules, producing undefined behavior when combined with `Error::context`.
- Fix: `cargo update -p anyhow --precise 1.0.103` (the fixed version per the advisory). `Cargo.lock` is the only file that changes.
- Corresponds to code scanning alert [#107](https://github.com/zakuro-ai/sakura/security/code-scanning/107).

## Test plan
- [x] `cargo check --workspace --all-features` — passes cleanly with the bumped lockfile.
- [x] `osv-scanner --lockfile=uv.lock --lockfile=Cargo.lock --recursive --format=table` (same invocation as CI, just with `--format=table` for readability) — now reports **"No issues found"**, exit 0.
- [ ] `cargo test --workspace` — could not be exercised locally: this repo's `sakura-wire` crate builds as a `pyo3` `extension-module`, which cannot link standalone on macOS arm64 outside a Python-linked interpreter context (confirmed this is a pre-existing local-only limitation by reproducing the identical linker failure on unmodified `master` before this change — unrelated to the anyhow bump). CI's `test.yml` (`cargo test --workspace --all-features` on `ubuntu-latest`) and the `python` maturin-based jobs are the correct place to validate this; please let those gates run on this PR.