### PR TITLE
fix: use zakuro-ai.com for contact addresses, not the third-party zakuro.ai

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Sakura: SOTA training services for PyTorch DDP / Lightning / Hugg
 readme = "README.md"
 license = "BSD-3-Clause"
 requires-python = ">=3.10"
-authors = [{ name = "ZakuroAI", email = "git@zakuro.ai" }]
+authors = [{ name = "ZakuroAI", email = "git@zakuro-ai.com" }]
 dependencies = [
     "tqdm>=4.68.1",
     "numpy",


### PR DESCRIPTION
`zakuro.ai` is not our domain — `zakuro-ai.com` is. This replaces the contact and author addresses in this repo, which route mail to an outside party.

**Deliberately limited to unambiguous contact/author metadata** (`git@`, `dev@`, `support@`). Three kinds of reference are left alone on purpose, because replacing them in a file does not change the thing they identify:

- **Live account identifiers** — `admin@zakuro.ai` (the staging dashboard admin the zak-journey harness logs in with) and `demo@zakuro.ai`. Editing these breaks auth unless the seeded account is changed first.
- **Applied SQL migrations** — `platform-house@zakuro.ai` is a seeded row in a migration already applied to the staging database. Editing the file would create drift between the migration and the live row rather than fixing anything.
- **Genuine references to the third-party site** — e.g. prose comparing a design direction to `zakuro.ai`, and changelog entries recording what a build step *used to* fetch.

Those need a data change, not a text change, and are tracked separately.

Verified: JSON/TOML/YAML still parse after the edit.